### PR TITLE
Do not override CMAKE_INSTALL_LIBDIR

### DIFF
--- a/cmake/G4RootConfig.cmake.in
+++ b/cmake/G4RootConfig.cmake.in
@@ -11,7 +11,7 @@
 # It defines the following variables
 #  G4Root_INCLUDE_DIRS         - include directories for G4Root
 #  G4Root_LIBRARIES            - libraries to link against G4Root
-#  CMAKE_INSTALL_LIBDIR        - library installation directory
+#  G4Root_CMAKE_INSTALL_LIBDIR - library installation directory
 #
 # I. Hrivnacova, 13/06/2014
 
@@ -20,7 +20,7 @@ get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_prefix "${_dir}/../.." ABSOLUTE)
 
 # Import options
-set(CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)
+set(G4Root_CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)
 
 # Import targets
 include("${_prefix}/@CMAKE_INSTALL_LIBDIR@/G4Root-@Geant4VMCPackages_VERSION@/G4RootTargets.cmake")

--- a/cmake/Geant4VMCConfig.cmake.in
+++ b/cmake/Geant4VMCConfig.cmake.in
@@ -19,7 +19,7 @@
 #  Geant4VMC_USE_GEANT4_G3TOG4 - build option: with Geant4 G3toG4 library
 #  G4Root_INCLUDE_DIRS         - include directories for G4Root (if with internal G4Root)
 #  G4Root_LIBRARIES            - libraries to link against G4Root (if with internal G4Root)
-#  CMAKE_INSTALL_LIBDIR        - library installation directory
+#  Geant4VMC_CMAKE_INSTALL_LIBDIR - library installation directory
 #
 # I. Hrivnacova, 13/06/2014
 
@@ -34,7 +34,7 @@ set(Geant4VMC_USE_VGM    @Geant4VMC_USE_VGM@)
 set(Geant4VMC_USE_GEANT4_UI  @Geant4VMC_USE_GEANT4_UI@)
 set(Geant4VMC_USE_GEANT4_VIS @Geant4VMC_USE_GEANT4_VIS@)
 set(Geant4VMC_USE_GEANT4_G3TOG4 @Geant4VMC_USE_GEANT4_G3TOG4@)
-set(CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)
+set(Geant4VMC_CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)
 
 # Import targets
 if (Geant4VMC_USE_G4Root AND (NOT Geant4VMC_USE_EXTERN_G4Root))

--- a/cmake/MTRootConfig.cmake.in
+++ b/cmake/MTRootConfig.cmake.in
@@ -11,7 +11,7 @@
 # It defines the following variables
 #  MTRoot_INCLUDE_DIRS         - include directories for MTRoot
 #  MTRoot_LIBRARIES            - libraries to link against MTRoot
-#  CMAKE_INSTALL_LIBDIR        - library installation directory
+#  MTRoot_CMAKE_INSTALL_LIBDIR - library installation directory
 #
 # I. Hrivnacova, 13/06/2014
 
@@ -20,7 +20,7 @@ get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_prefix "${_dir}/../.." ABSOLUTE)
 
 # Import options
-set(CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)
+set(MTRoot_CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)
 
 # Import targets
 include("${_prefix}/@CMAKE_INSTALL_LIBDIR@/MTRoot-@Geant4VMCPackages_VERSION@/MTRootTargets.cmake")


### PR DESCRIPTION
Doing this will cause naming conflict with e.g. the CMake native
`GNUInstallDirs` module. In general, CMake package scripts should not
override `CMAKE_*` variables.