### PR TITLE
Implement TGeant4 and TG4RunManager::ProcessEvent()

### DIFF
--- a/source/run/include/TG4RunManager.h
+++ b/source/run/include/TG4RunManager.h
@@ -56,6 +56,7 @@ class TG4RunManager : public TG4Verbose
     void CacheMCStack();
     void ProcessEvent();
     Bool_t ProcessRun(G4int nofEvents);
+    Bool_t FinishRun();
 
     // get methods
     Int_t   CurrentEvent() const;
@@ -109,6 +110,9 @@ class TG4RunManager : public TG4Verbose
     char**                fARGV;             ///< argv
     G4bool                fUseRootRandom;    ///< the option to use Root random number seed
     G4bool                fIsMCStackCached;  ///< the flag to cache MC stack only once
+    G4bool                fHasEventByEventInitialization; ///< Flag event-by-event processing
+    G4int                 fNEventsProcessed; ///< Number of events processed in event-by-event mode
+    G4bool                fInProcessRun;     ///< flag while being in BeamOn
 };
 
 // inline methods

--- a/source/run/include/TGeant4.h
+++ b/source/run/include/TGeant4.h
@@ -334,6 +334,7 @@ class TGeant4: public TVirtualMC
     virtual void   InitMT(Int_t threadRank);
     virtual void   ProcessEvent();
     virtual Bool_t ProcessRun(Int_t nofEvents);
+    Bool_t         FinishRun();
     virtual void   SetCollectTracks(Bool_t collectTracks);
     virtual Bool_t IsCollectTracks() const;
     virtual Bool_t IsMT() const;

--- a/source/run/src/TGeant4.cxx
+++ b/source/run/src/TGeant4.cxx
@@ -1218,6 +1218,14 @@ Bool_t TGeant4::ProcessRun(Int_t nofEvents)
 }  
 
 //_____________________________________________________________________________
+Bool_t TGeant4::FinishRun()
+{
+/// Process Geant4 run.
+
+  return fRunManager->FinishRun();
+}
+
+//_____________________________________________________________________________
 void TGeant4::SetCollectTracks(Bool_t collectTracks)
 {
 /// (In)Activate collecting TGeo tracks 


### PR DESCRIPTION
This commit enables for an event-by-event processing in TGeant4 by replaying what is done during G4RunManager::BeamOn but leaving out the event loop.

Initialization procedures are only made once.

In case of using TGeant4::ProcesEvent() the user should also call TGeant4::FinishRun() after all events have been processed. The latter one is at the moment only implemented in TGeant4 and not inherited from TVirtualMC.

TGeant4::FinishRun() is called automatically for TGeant4::ProcessRun().

Calling TGeant4::ProcessRun() after TGeant4::ProcessEvent() without having called TGeant4::FinishRun() in between, it will be invoked automatically. It is also possible to do another event-by-event processing after TGeant4::ProcessRun().