### PR TITLE
Test fixes

### DIFF
--- a/examples/test_suite.sh
+++ b/examples/test_suite.sh
@@ -182,7 +182,7 @@ fi
 # Set path to shared libraries if --builddir is provided via the option
 if [ "x${BUILDDIR}" != "x" ]; then
   LIBS_FROM_BUILDDIR=$(find ${BUILDDIR} -iname "*.so" -exec dirname {} \; | tr '\r\n' ':')
-  LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBS_FROM_BUILDDIR}
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBS_FROM_BUILDDIR}
 fi
 
 # Create tmp dir from scratch

--- a/examples/test_suite_exe.sh
+++ b/examples/test_suite_exe.sh
@@ -189,6 +189,10 @@ do
         mkdir -p $OUT
       fi
 
+      if [ "x${BUILDDIR}" != "x" ]; then
+        EXEDIR=${BUILDDIR}/examples/$EXAMPLE/$OPTION/
+      fi
+
       cd $CURDIR/$EXAMPLE
       start_test "... Example $EXAMPLE/$OPTION"
 


### PR DESCRIPTION
This fixes several issues related to `builddir`:
- `LD_LIBRARY_PATH` was not `export`ed for `test_suite` (regression). 
- Paths to `E03` sub-examples were incorrect, since the executables are in the corresponding sub-directories during build. 