### PR TITLE
OpNovice: Use "UseGeant4" instead of ${Geant4_USE_FILE}.

### DIFF
--- a/g4root/test/OpNovice/CMakeLists.txt
+++ b/g4root/test/OpNovice/CMakeLists.txt
@@ -44,7 +44,9 @@ endif()
 #----------------------------------------------------------------------------
 # Setup Geant4 include directories and compile definitions
 #
-include(${Geant4_USE_FILE})
+# Workaround for upstream bug: http://bugzilla-geant4.kek.jp/show_bug.cgi?id=1663
+#include(${Geant4_USE_FILE})
+include(UseGeant4)
 
 #----------------------------------------------------------------------------
 # Locate sources and headers for this project


### PR DESCRIPTION
Apparently I missed this location in the past which meant
the OpNovice example was still built without honouring
user CFLAGS. Now it matches all other build targets.