### PR TITLE
Update CMake minimum version in examples and g4root/test to 2.8.12

### DIFF
--- a/examples/A01/CMakeLists.txt
+++ b/examples/A01/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project A01

--- a/examples/A01/geant4/CMakeLists.txt
+++ b/examples/A01/geant4/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project g4A01

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -13,7 +13,8 @@
 #---Adding examples subdirectories explicitly
 #   and a custom target to for building all VMC examples -------------
 
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 set(CMAKE_MODULE_PATH
     ${Geant4VMC_DIR}/Modules

--- a/examples/E01/CMakeLists.txt
+++ b/examples/E01/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project E01

--- a/examples/E02/CMakeLists.txt
+++ b/examples/E02/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project E02

--- a/examples/E03/CMakeLists.txt
+++ b/examples/E03/CMakeLists.txt
@@ -13,7 +13,8 @@
 #---Adding examples subdirectories explicitly
 #   and a custom target to for building all VMC examples -------------
 
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 if(VMC_WITH_Multi)
 add_subdirectory(E03c)

--- a/examples/E03/E03a/CMakeLists.txt
+++ b/examples/E03/E03a/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project E03a

--- a/examples/E03/E03a/geant4/CMakeLists.txt
+++ b/examples/E03/E03a/geant4/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project geant4E03a

--- a/examples/E03/E03b/CMakeLists.txt
+++ b/examples/E03/E03b/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project E03b

--- a/examples/E03/E03b/geant4/CMakeLists.txt
+++ b/examples/E03/E03b/geant4/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project geant4E03b

--- a/examples/E03/E03c/CMakeLists.txt
+++ b/examples/E03/E03c/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project E03c

--- a/examples/E03/E03c/geant4/CMakeLists.txt
+++ b/examples/E03/E03c/geant4/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project geant4E03c

--- a/examples/E06/CMakeLists.txt
+++ b/examples/E06/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project E06

--- a/examples/ExGarfield/CMakeLists.txt
+++ b/examples/ExGarfield/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project ExGarfield

--- a/examples/ExGarfield/geant4/CMakeLists.txt
+++ b/examples/ExGarfield/geant4/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project geant4ExGarfield

--- a/examples/Gflash/CMakeLists.txt
+++ b/examples/Gflash/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project Gflash

--- a/examples/Monopole/CMakeLists.txt
+++ b/examples/Monopole/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project Monopole

--- a/examples/TR/CMakeLists.txt
+++ b/examples/TR/CMakeLists.txt
@@ -12,7 +12,8 @@
 
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 #----------------------------------------------------------------------------
 # Project TR

--- a/g4root/test/CMakeLists.txt
+++ b/g4root/test/CMakeLists.txt
@@ -2,7 +2,8 @@
 
 #---Adding the OpNovice subdirectory explicitly
 
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 
 set(CMAKE_MODULE_PATH
     ${Geant4VMC_DIR}/Modules

--- a/g4root/test/OpNovice/CMakeLists.txt
+++ b/g4root/test/OpNovice/CMakeLists.txt
@@ -1,6 +1,7 @@
 #----------------------------------------------------------------------------
 # Setup the project
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+
 project(OpNovice)
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes CMake deprecation warnings (on MacOS)