### PR TITLE
Make sure that TGeo is using the old Root units

### DIFF
--- a/source/geometry/src/TG4GeometryManager.cxx
+++ b/source/geometry/src/TG4GeometryManager.cxx
@@ -296,9 +296,12 @@ void TG4GeometryManager::ConstructG4Geometry()
     if (VerboseLevel() > 1)
       G4cout << "Running TVirtualMCApplication::ConstructGeometry" << G4endl;
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 22, 8)
     // Set Root default units to TGeo
     TGeoManager::LockDefaultUnits(false);
     TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+    TGeoManager::LockDefaultUnits(true);
+#endif
 
     TG4StateManager::Instance()->SetNewState(kConstructGeometry);
     TVirtualMCApplication::Instance()->ConstructGeometry();

--- a/source/geometry/src/TG4GeometryManager.cxx
+++ b/source/geometry/src/TG4GeometryManager.cxx
@@ -296,6 +296,10 @@ void TG4GeometryManager::ConstructG4Geometry()
     if (VerboseLevel() > 1)
       G4cout << "Running TVirtualMCApplication::ConstructGeometry" << G4endl;
 
+    // Set Root default units to TGeo
+    TGeoManager::LockDefaultUnits(false);
+    TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+
     TG4StateManager::Instance()->SetNewState(kConstructGeometry);
     TVirtualMCApplication::Instance()->ConstructGeometry();
     TG4StateManager::Instance()->SetNewState(kNotInApplication);

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -193,6 +193,10 @@ void TG4RunManager::ConfigureRunManager()
   TG4RootNavMgr* rootNavMgr = 0;
   if (userGeometry == "VMCtoRoot" || userGeometry == "Root") {
     if (!TMCManager::Instance()) {
+      // Set Root default units to TGeo
+      TGeoManager::LockDefaultUnits(false);
+      TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+
       // Construct geometry via VMC application
       if (TG4GeometryManager::Instance()->VerboseLevel() > 0)
         G4cout << "Running TVirtualMCApplication::ConstructGeometry"

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -193,9 +193,13 @@ void TG4RunManager::ConfigureRunManager()
   TG4RootNavMgr* rootNavMgr = 0;
   if (userGeometry == "VMCtoRoot" || userGeometry == "Root") {
     if (!TMCManager::Instance()) {
+
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 22, 8)
       // Set Root default units to TGeo
       TGeoManager::LockDefaultUnits(false);
       TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+      TGeoManager::LockDefaultUnits(true);
+#endif
 
       // Construct geometry via VMC application
       if (TG4GeometryManager::Instance()->VerboseLevel() > 0)


### PR DESCRIPTION
The default TGeo units (cm, s, GeV) has been changed in Root v6.24
to Geant4 defaults (mm, ns, MeV); while the VMC is based on the old system