### PR TITLE
Updated cmake (continued):

### DIFF
--- a/cmake/FindVMCPackages.cmake
+++ b/cmake/FindVMCPackages.cmake
@@ -14,7 +14,6 @@
 # I. Hrivnacova, 26/02/2014
 
 #---Options---------------------------------------------------------------------
-option(VMC_WITH_MTRoot      "Build with MTRoot" ON)
 option(VMC_INSTALL_EXAMPLES "Install examples libraries and programs" ON)
 option(BUILD_SHARED_LIBS    "Build the dynamic libraries" ON)
 
@@ -22,6 +21,11 @@ option(BUILD_SHARED_LIBS    "Build the dynamic libraries" ON)
 
 # ROOT (required)
 find_package(ROOT CONFIG REQUIRED)
+# Cannot mix VMC standalone and vmc in ROOT (deprecated)
+if(ROOT_vmc_FOUND)
+  message(FATAL_ERROR
+          "Cannot use VMC standalone with ROOT built with vmc.")
+endif()
 include(${ROOT_USE_FILE})
 set (ROOT_LIBRARIES ${ROOT_LIBRARIES} -lEG -lGeom)
 

--- a/cmake/Geant4VMCRequiredPackages.cmake
+++ b/cmake/Geant4VMCRequiredPackages.cmake
@@ -16,30 +16,17 @@
 
 #-- ROOT (required) ------------------------------------------------------------
 find_package(ROOT CONFIG REQUIRED COMPONENTS EG Geom REQUIRED)
+# Cannot mix VMC standalone and vmc in ROOT (deprecated)
+if(ROOT_vmc_FOUND)
+  message(FATAL_ERROR
+          "Cannot use VMC standalone with ROOT built with vmc.")
+endif()
 set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Tree ROOT::Rint ROOT::Physics
     ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG)
 include(${ROOT_USE_FILE})
 
 #-- VMC (required) ------------------------------------------------------------
-find_package(VMC CONFIG)
-# first try VMC standalone (default)
-if(VMC_FOUND)
-  if(NOT VMC_FIND_QUIETLY)
-    message(STATUS "Found VMC ${VMC_VERSION} in ${VMC_DIR}")
-  endif()
-else()
-  # otherwise fallback to ROOT's internal if possible (deprecated)
-  if(ROOT_vmc_FOUND)
-    message(WARNING "Using VMC built with ROOT - Deprecated")
-    set(VMC_LIBRARIES ROOT::VMC)
-    add_definitions(-DUSE_ROOT_VMC)
-  else()
-    message(FATAL_ERROR
-            "Could not find VMC package. "
-            "VMC package is not provided with ROOT since v6.26/00. "
-            "Please, install it from https://github.com/vmc-project/vmc. ")
-  endif()
-endif()
+find_package(VMC CONFIG REQUIRED)
 
 #-- Geant4 (required) ----------------------------------------------------------
 set(_components)


### PR DESCRIPTION
- Removed fallback to ROOT's internal VMC and added fatal error
  if VMC is found in ROOT in Geant4VMCRequiredPackages and FindVMCPackages
- Removed VMC_BUILD_MTRoot option and usage of MTRoot package