### PR TITLE
Fixes in applying cuts and processes maps:

### DIFF
--- a/source/event/src/TG4SteppingAction.cxx
+++ b/source/event/src/TG4SteppingAction.cxx
@@ -149,11 +149,14 @@ void TG4SteppingAction::ProcessTrackIfOutOfRegion(const G4Step* step)
 //_____________________________________________________________________________
 void TG4SteppingAction::ProcessTrackIfBelowCut(const G4Step* step)
 {
-  /// Flag e+e- secondary pair for stop if its energy is below user cut
+  /// Flag e+e- secondary pair produced by muons for stop if its energy 
+  /// is below user cut (PPCUTM)
 
-  if (step->GetSecondary()->size() == 2 &&
-      ((*step->GetSecondary())[0]->GetCreatorProcess()->GetProcessName() ==
+  if (step->GetSecondaryInCurrentStep()->size() == 2 &&
+      ((*step->GetSecondaryInCurrentStep())[0]->GetCreatorProcess()->GetProcessName() ==
         "muPairProd")) {
+             // Process sub type fPairProdByCharged does distinguish the creator
+             // particle type
 
     G4double minEtotPair =
       fStepManager->GetCurrentLimits()->GetCutVector()->GetMinEtotPair();

--- a/source/global/src/TG4G3CutVector.cxx
+++ b/source/global/src/TG4G3CutVector.cxx
@@ -240,10 +240,10 @@ void TG4G3CutVector::SetCut(TG4G3Cut cut, G4double cutValue)
 
   // Set the CUTELE value also to DCUTE, DCUTM unless they were already set
   if (cut == kCUTELE) {
-    if (!fIsBCUTE) {
+    if (!fIsDCUTE) {
       fCutVector[kDCUTE] = cutValue;
     }
-    if (!fIsBCUTM) {
+    if (!fIsDCUTM) {
       fCutVector[kDCUTM] = cutValue;
     }
   }

--- a/source/physics_list/include/TG4ProcessControlMapPhysics.h
+++ b/source/physics_list/include/TG4ProcessControlMapPhysics.h
@@ -1,5 +1,5 @@
-#ifndef TG4_PROCESS_MAP_PHYSICS_H
-#define TG4_PROCESS_MAP_PHYSICS_H
+#ifndef TG4_PROCESS_CONTROL_MAP_PHYSICS_H
+#define TG4_PROCESS_CONTROL_MAP_PHYSICS_H
 
 //------------------------------------------------
 // The Geant4 Virtual Monte Carlo package
@@ -50,4 +50,4 @@ class TG4ProcessControlMapPhysics : public TG4VPhysicsConstructor
   void FillMap(G4bool isBiasing);
 };
 
-#endif // TG4_PROCESS_MAP_PHYSICS_H
+#endif // TG4_PROCESS_CONTROL_MAP_PHYSICS_H

--- a/source/physics_list/src/TG4ProcessControlMapPhysics.cxx
+++ b/source/physics_list/src/TG4ProcessControlMapPhysics.cxx
@@ -222,17 +222,17 @@ void TG4ProcessControlMapPhysics::FillMap(G4bool isBiasing)
   controlMap->Add("hInelastic", kHADR);
   controlMap->Add("CHIPS_Inelastic", kHADR);
 
-  controlMap->Add("nKiller", kHADR);
+  controlMap->Add("nKiller", kNoG3Controls);
 
   controlMap->Add("muNucl", kMUNU);
   controlMap->Add("muonNuclear", kMUNU);
-  controlMap->Add("muMinusCaptureAtRest", kMUNU);
-  controlMap->Add("PositronNuclear", kNoG3Controls);
-  controlMap->Add("positronNuclear", kNoG3Controls);
-  controlMap->Add("ElectroNuclear", kNoG3Controls);
-  controlMap->Add("electronNuclear", kNoG3Controls);
-  controlMap->Add("photoNuclear", kNoG3Controls);
-  controlMap->Add("photonNuclear", kNoG3Controls);
+  controlMap->Add("muMinusCaptureAtRest", kHADR);
+  controlMap->Add("PositronNuclear", kHADR);
+  controlMap->Add("positronNuclear", kHADR);
+  controlMap->Add("ElectroNuclear", kHADR);
+  controlMap->Add("electronNuclear", kHADR);
+  controlMap->Add("photoNuclear", kHADR);
+  controlMap->Add("photonNuclear", kHADR);
 
   controlMap->Add("Cerenkov", kCKOV);
   controlMap->Add("Scintillation", kNoG3Controls);
@@ -302,7 +302,8 @@ void TG4ProcessControlMapPhysics::ConstructProcess()
           processName != "StrawXTRadiator" &&
           processName != "RegularXTRadiator" &&
           processName != "G4MaxTimeCuts" && processName != "biasWrapper(0)" &&
-          processName != "GammaGeneralProc" && processName != "biasLimiter") {
+          processName != "GammaGeneralProc" && processName != "biasLimiter" &&
+          processName != "nKiller") {
 
         G4String text = "Unknown process control for ";
         text += processName;

--- a/source/physics_list/src/TG4ProcessMCMapPhysics.cxx
+++ b/source/physics_list/src/TG4ProcessMCMapPhysics.cxx
@@ -102,15 +102,16 @@ void TG4ProcessMCMapPhysics::FillMap(G4bool isBiasing)
   mcMap->Add("nFission", kPNuclearFission);
   mcMap->Add("HadronFission", kPNuclearFission);
 
-  mcMap->Add("PiMinusAbsorptionAtRest", kPNuclearAbsorption);
-  mcMap->Add("PiMinusAbsorptionBertini", kPNuclearAbsorption);
-  mcMap->Add("PionMinusAbsorptionAtRest", kPNuclearAbsorption);
-  mcMap->Add("KaonMinusAbsorption", kPNuclearAbsorption);
-  mcMap->Add("KaonMinusAbsorptionAtRest", kPNuclearAbsorption);
-  mcMap->Add("CHIPSNuclearCaptureAtRest", kPNuclearAbsorption);
-  mcMap->Add("FTFNuclearCaptureAtRest", kPNuclearAbsorption);
-  mcMap->Add("hFritiofCaptureAtRest", kPNuclearAbsorption);
-  mcMap->Add("hBertiniCaptureAtRest", kPNuclearAbsorption);
+  mcMap->Add("PiMinusAbsorptionAtRest", kPHadronic);
+  mcMap->Add("PiMinusAbsorptionBertini", kPHadronic);
+  mcMap->Add("PionMinusAbsorptionAtRest", kPHadronic);
+  mcMap->Add("KaonMinusAbsorption", kPHadronic);
+  mcMap->Add("KaonMinusAbsorptionAtRest", kPHadronic);
+  mcMap->Add("CHIPSNuclearCaptureAtRest", kPHadronic);
+  mcMap->Add("FTFNuclearCaptureAtRest", kPHadronic);
+  mcMap->Add("hFritiofCaptureAtRest", kPHadronic);
+  mcMap->Add("hBertiniCaptureAtRest", kPHadronic);
+  mcMap->Add("muMinusCaptureAtRest", kPHadronic);
 
   mcMap->Add("AntiProtonAnnihilationAtRest", kPPbarAnnihilation);
   mcMap->Add("AntiNeutronAnnihilationAtRest", kPNbarAnnihilation);
@@ -224,11 +225,10 @@ void TG4ProcessMCMapPhysics::FillMap(G4bool isBiasing)
   mcMap->Add("CHIPS_Inelastic", kPHInhelastic);
   mcMap->Add("PhotonInelastic", kPPhotonInhelastic);
 
-  mcMap->Add("nKiller", kPHadronic);
+  mcMap->Add("nKiller", kPStop);
 
   mcMap->Add("muNucl", kPMuonNuclear);
   mcMap->Add("muonNuclear", kPMuonNuclear);
-  mcMap->Add("muMinusCaptureAtRest", kPMuonNuclear);
   mcMap->Add("PositronNuclear", kPPositronNuclear);
   mcMap->Add("positronNuclear", kPPositronNuclear);
   mcMap->Add("ElectroNuclear", kPElectronNuclear);
@@ -243,8 +243,8 @@ void TG4ProcessMCMapPhysics::FillMap(G4bool isBiasing)
   mcMap->Add("Rayl", kPRayleigh);
   mcMap->Add("OpBoundary", kPLightScattering);
   mcMap->Add("OpMieHG", kPLightScattering);
-  mcMap->Add("OpWLS", kPNull);
-  mcMap->Add("OpWLS2", kPNull);
+  mcMap->Add("OpWLS", kPLightWLShifting);
+  mcMap->Add("OpWLS2", kPLightWLShifting);
 // Available since 6.07/03 and 5.34/35
 #if ((ROOT_VERSION_CODE >= ROOT_VERSION(6, 7, 3)) ||  \
      ((ROOT_VERSION_CODE <= ROOT_VERSION(6, 0, 0)) && \
@@ -277,7 +277,7 @@ void TG4ProcessMCMapPhysics::FillMap(G4bool isBiasing)
   mcMap->Add("G4MaxTimeCuts", kPStop);
   mcMap->Add("stackPopper", kPUserDefined);
 
-  mcMap->Add("biasLimiter", kPNull);
+  mcMap->Add("biasLimiter", kStepMax);
   mcMap->Add("biasWrapper(0)", kPNull);
   mcMap->Add("GammaGeneralProc", kPNull);
 }


### PR DESCRIPTION
- Fixed mapping of some hadronic processes
- Fixed applying PPCUTM:
   Using G4Step::GetSecondaryInCurrentStep() instead of GetSecondary(),
   as the second one provides accummulated secondaries since the first step
- Fix in development in PR #26