### PR TITLE
Fixes for v6-1-p2

### DIFF
--- a/examples/macro/g3libs.C
+++ b/examples/macro/g3libs.C
@@ -37,9 +37,9 @@ void g3libs()
 /// Macro function for loading Geant3 libraries
 
   // Load libraries required by Geant3
+  gSystem->Load("libPythia6");
   gSystem->Load("libEG");
   gSystem->Load("libEGPythia6");
-  gSystem->Load("libPythia6");
 
   // VMC library (optional)
   if ( g3libUtilities::isLibrary("libVMCLibrary") ) {

--- a/examples/test_suite_exe.sh
+++ b/examples/test_suite_exe.sh
@@ -38,7 +38,7 @@ TESTGARFIELD="1"
 RUN_ENV=""
 if [[ ${ROOT_LD_LIBRARY_PATH} ]]
 then
-  RUN_ENV="env LD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
+  RUN_ENV="env DYLD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
 fi
 
 # The default list of examples (all)

--- a/source/physics_list/src/TG4ExtraPhysicsList.cxx
+++ b/source/physics_list/src/TG4ExtraPhysicsList.cxx
@@ -18,6 +18,7 @@
 
 #include <G4EmExtraPhysics.hh>
 #include <G4GenericBiasingPhysics.hh>
+#include <G4HadronicParameters.hh>
 #include <G4MonopolePhysics.hh>
 #include <G4OpticalPhysics.hh>
 #include <G4RadioactiveDecayPhysics.hh>
@@ -78,7 +79,7 @@ G4String TG4ExtraPhysicsList::AvailableSelections()
   /// Return list of all available selections
 
   G4String selections;
-  selections += "biasing extra monopole optical radDecay ";
+  selections += "biasing extra monopole optical radDecay hyperNuclei ";
 
   return selections;
 }
@@ -173,6 +174,12 @@ void TG4ExtraPhysicsList::Configure(
   // Radioactive decay physics
   if (G4StrUtil::contains(selection, "radDecay")) {
     RegisterPhysics(new G4RadioactiveDecayPhysics());
+  }
+
+  // Hyper-nuclei physics
+  if (G4StrUtil::contains(selection, "hyperNuclei")) {
+    // activate hyper-nuclei processes
+    G4HadronicParameters::Instance()->SetEnableHyperNuclei(true);
   }
 }
 


### PR DESCRIPTION
Geant4 VMC:
 -  Added "hyperNuclei" option to the extra physics constructor (#37)
       (This allows to activate hyper-nuclei processes at the physics list
       constructor.)

Examples:
- Fixes in example test_suite needed for macOS Monteray
