### PR TITLE
Migration to Geant4 11.1, fixes in examples test suites:

### DIFF
--- a/cmake/Geant4VMCRequiredPackages.cmake
+++ b/cmake/Geant4VMCRequiredPackages.cmake
@@ -40,6 +40,7 @@ if(Geant4VMC_USE_GEANT4_G3TOG4)
   list(APPEND _components g3tog4)
 endif()
 find_package(Geant4 CONFIG REQUIRED ${_components})
+set(CMAKE_CXX_STANDARD ${Geant4_CXX_STANDARD})
 
 #-- VGM (optional) -------------------------------------------------------------
 if (Geant4VMC_USE_VGM)

--- a/examples/run_suite.sh
+++ b/examples/run_suite.sh
@@ -26,12 +26,12 @@ TESTG4="1"
 TESTMULTI="1"
 TESTGARFIELD="1"
 
-# When running on Mac with SIP enabled, the LD_LIBRARY_PATH must be defined
+# When running on Mac with SIP enabled, the DYLD_LIBRARY_PATH must be defined
 # via another env variable
 RUN_ENV=""
 if [[ ${ROOT_LD_LIBRARY_PATH} ]]
 then
-  RUN_ENV="env LD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
+  RUN_ENV="env DYLD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
 fi
 
 # The default list of examples (all)
@@ -51,7 +51,7 @@ function run_mc()
 function run_multi()
 {
   echo "    - with multiple engines"
-  $RUN_env root.exe -q -b load_multi.C run_multi.C >& $OUT/run_multi.out
+  $RUN_ENV root.exe -q -b load_multi.C run_multi.C >& $OUT/run_multi.out
 }
 
 # Process script arguments

--- a/examples/run_suite_exe.sh
+++ b/examples/run_suite_exe.sh
@@ -26,12 +26,12 @@ TESTG3="1"
 TESTG4="1"
 TESTMULTI="1"
 
-# When running on Mac with SIP enabled, the LD_LIBRARY_PATH must be defined
+# When running on Mac with SIP enabled, the DYLD_LIBRARY_PATH must be defined
 # via another env variable
 RUN_ENV=""
 if [[ ${ROOT_LD_LIBRARY_PATH} ]]
 then
-  RUN_ENV="env LD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
+  RUN_ENV="env DYLD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
 fi
 
 # Run Garfield optionally

--- a/examples/test_physics_lists.sh
+++ b/examples/test_physics_lists.sh
@@ -19,12 +19,12 @@
 CURDIR=`pwd`
 OUTDIR=$CURDIR/log/test_physics_lists
 
-# When running on Mac with SIP enabled, the LD_LIBRARY_PATH must be defined
+# When running on Mac with SIP enabled, the DYLD_LIBRARY_PATH must be defined
 # via another env variable
 RUN_ENV=""
 if [[ ${ROOT_LD_LIBRARY_PATH} ]]
 then
-  RUN_ENV="env LD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
+  RUN_ENV="env DYLD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
 fi
 
 # Define path to optional data files

--- a/examples/test_suite.sh
+++ b/examples/test_suite.sh
@@ -46,12 +46,12 @@ BUILDDIR=""
 # Run Garfield optionally
 TESTGARFIELD="1"
 
-# When running on Mac with SIP enabled, the LD_LIBRARY_PATH must be defined
+# When running on Mac with SIP enabled, the DYLD_LIBRARY_PATH must be defined
 # via another env variable
 RUN_ENV=""
 if [[ ${ROOT_LD_LIBRARY_PATH} ]]
 then
-  RUN_ENV="env LD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
+  RUN_ENV="env DYLD_LIBRARY_PATH=${ROOT_LD_LIBRARY_PATH} "
 fi
 
 # Root command with loading g3/g4 libraries

--- a/examples/test_suite_exe.sh
+++ b/examples/test_suite_exe.sh
@@ -33,7 +33,7 @@ BUILDDIR=""
 # Run Garfield only with Root 5
 TESTGARFIELD="1"
 
-# When running on Mac with SIP enabled, the LD_LIBRARY_PATH must be defined
+# When running on Mac with SIP enabled, the DYLD_LIBRARY_PATH must be defined
 # via another env variable
 RUN_ENV=""
 if [[ ${ROOT_LD_LIBRARY_PATH} ]]

--- a/source/digits+hits/src/TG4StepManager.cxx
+++ b/source/digits+hits/src/TG4StepManager.cxx
@@ -1312,7 +1312,7 @@ TMCProcess TG4StepManager::ProdProcess(Int_t isec) const
   CheckStep("ProdProcess");
 #endif
 
-  TG4SteppingAction::Instance()->ProcessTrackIfGammaGeneral(fStep);
+  TG4SteppingAction::Instance()->ProcessTrackIfGeneralProcess(fStep);
     // If this funcion is called from SD, it is earlier than TG4SteppingAction
     // fixes the creator processes
 
@@ -1374,7 +1374,7 @@ Int_t TG4StepManager::StepProcesses(TArrayI& processes) const
   CheckStep("StepProcesses");
 #endif
 
-  TG4SteppingAction::Instance()->ProcessTrackIfGammaGeneral(fStep);
+  TG4SteppingAction::Instance()->ProcessTrackIfGeneralProcess(fStep);
     // If this funcion is called from SD, it is earlier than TG4SteppingAction
     // fixes the creator processes
 

--- a/source/event/include/TG4SteppingAction.h
+++ b/source/event/include/TG4SteppingAction.h
@@ -59,7 +59,7 @@ class TG4SteppingAction : public G4UserSteppingAction
   static TG4SteppingAction* Instance();
 
   // methods
-  void ProcessTrackIfGammaGeneral(const G4Step* step);
+  void ProcessTrackIfGeneralProcess(const G4Step* step);
   void LateInitialize();
   virtual void SteppingAction(const G4Step* step);
   // the following method should not

--- a/source/event/src/TG4SteppingAction.cxx
+++ b/source/event/src/TG4SteppingAction.cxx
@@ -27,6 +27,8 @@
 
 #include <G4EmParameters.hh>
 #include <G4Gamma.hh>
+#include <G4HadronicParameters.hh>
+#include <G4Neutron.hh>
 #include <G4SteppingManager.hh>
 #include <G4Track.hh>
 
@@ -279,35 +281,39 @@ void TG4SteppingAction::PrintTrackInfo(const G4Track* track) const
 //
 
 //_____________________________________________________________________________
-void TG4SteppingAction::ProcessTrackIfGammaGeneral(const G4Step* step)
+void TG4SteppingAction::ProcessTrackIfGeneralProcess(const G4Step* step)
 {
   /// Make sure that the creator process (of the secondary tracks of the
   /// current step) is the same as the one that limited the step.
   /// These can be different in case of using `wrapper` processes e.g.
   /// G4GammaGeneralProcess or G4HepEm, etc.
 
-  if (G4EmParameters::Instance()->GeneralProcessActive()) {
-    auto particle = step->GetTrack()->GetParticleDefinition();
-    auto nofSecondaries = step->GetNumberOfSecondariesInCurrentStep();
-    if (particle==G4Gamma::GammaDefinition() && nofSecondaries>0) {
-      // Get the pointer to the process that limited the step: i.e. the one that
-      // created the secondaries of the current step
-      const G4VProcess* limiterProcess =
-        step->GetPostStepPoint()->GetProcessDefinedStep();
-      // note: this is a vector of secondaries containing all secondaries created
-      // along the tracking of the current `primary` track (i.e. not only
-      // secondaries created in this step)
-      auto secondaries  = step->GetSecondary();
-      auto nofAllSecondaries = secondaries ->size();
-      for (auto it = nofAllSecondaries - nofSecondaries; it < nofAllSecondaries; ++it) {
-        auto secTrack = (*secondaries )[it];
-        if (secTrack->GetCreatorProcess() != limiterProcess) {
-          secTrack->SetCreatorProcess(limiterProcess);
-        }
+  auto gammaGeneral = G4EmParameters::Instance()->GeneralProcessActive();
+  auto neutronGeneral = G4HadronicParameters::Instance()->EnableNeutronGeneralProcess();
+
+  if ((! gammaGeneral) && (! neutronGeneral)) return;
+
+  auto particle = step->GetTrack()->GetParticleDefinition();
+  auto nofSecondaries = step->GetNumberOfSecondariesInCurrentStep();
+  if (((particle==G4Gamma::GammaDefinition() && gammaGeneral) ||
+       (particle==G4Neutron::NeutronDefinition() && neutronGeneral)) && nofSecondaries>0) {
+    // Get the pointer to the process that limited the step: i.e. the one that
+    // created the secondaries of the current step
+    const G4VProcess* limiterProcess =
+      step->GetPostStepPoint()->GetProcessDefinedStep();
+    // note: this is a vector of secondaries containing all secondaries created
+    // along the tracking of the current `primary` track (i.e. not only
+    // secondaries created in this step)
+    auto secondaries  = step->GetSecondary();
+    auto nofAllSecondaries = secondaries ->size();
+    for (auto it = nofAllSecondaries - nofSecondaries; it < nofAllSecondaries; ++it) {
+      auto secTrack = (*secondaries )[it];
+      if (secTrack->GetCreatorProcess() != limiterProcess) {
+        secTrack->SetCreatorProcess(limiterProcess);
       }
     }
   }
-} 
+}
 
 //_____________________________________________________________________________
 void TG4SteppingAction::LateInitialize()
@@ -329,8 +335,8 @@ void TG4SteppingAction::UserSteppingAction(const G4Step* step)
   /// there is defined SteppingAction(const G4Step* step) method
   /// for this purpose.
 
-  // Fix creator process for secondaries if using G4GammaGeneralProcess
-  ProcessTrackIfGammaGeneral(step);
+  // Fix creator process for secondaries if using gamma or neutron general process
+  ProcessTrackIfGeneralProcess(step);
 
   // stop track if maximum number of steps has been reached
   ProcessTrackIfLooping(step);

--- a/source/physics/src/TG4PhysicsManager.cxx
+++ b/source/physics/src/TG4PhysicsManager.cxx
@@ -750,6 +750,9 @@ TMCProcess TG4PhysicsManager::GetOpBoundaryStatus()
     case GroundTyvekAirReflection:
     case GroundVM2000AirReflection:
     case GroundVM2000GlueReflection:
+#if G4VERSION_NUMBER >= 1110
+    case CoatedDielectricReflection:
+#endif
       return kPLightReflection;
       ;
       ;
@@ -761,6 +764,12 @@ TMCProcess TG4PhysicsManager::GetOpBoundaryStatus()
 #endif
 #if G4VERSION_NUMBER >= 1010
     case Transmission:
+#endif
+#if G4VERSION_NUMBER >= 1110
+    case CoatedDielectricRefraction:
+#endif
+#if G4VERSION_NUMBER >= 1110
+    case CoatedDielectricFrustratedTransmission:
 #endif
       return kPLightRefraction;
       ;

--- a/source/physics_list/src/TG4ProcessMapPhysics.cxx
+++ b/source/physics_list/src/TG4ProcessMapPhysics.cxx
@@ -120,6 +120,7 @@ void TG4ProcessMapPhysics::FillMap()
 
   // G4HadronicProcessType: 111 - 161; 210; 310
   pMap->Add(fHadronElastic, kPHElastic, kHADR);                    // G4 value: 111
+  pMap->Add(fNeutronGeneral, kPNull, kNoG3Controls);               // G4 value: 116
   pMap->Add(fHadronInelastic, kPHInhelastic, kHADR);               // G4 value: 121
   pMap->Add(fCapture, kPNCapture, kHADR);                          // G4 value: 131
   pMap->Add(fMuAtomicCapture, kPHadronic, kHADR);                  // G4 value: 132


### PR DESCRIPTION
Migration to Geant4 11.1:
- Added support for G4NeutronGeneralProcess
- Added handling of CoatedDielectric* optical boundary processes (new in Geant4 11.1)
- Explicitly set CMAKE_CXX_STANDARD from Geant4 setting

Make examples test suites working on macOS Monterey with SIP enabled: 
- Renamed LD_LIBRARY_PATH, passed to the scripts via another env variable, in DYLD_LIBRARY_PATH
- Fixed $RUN_ENV (all letters upper case) in run_multi() in run_suite.sh
