### PR TITLE
Use ROOT::EnableThreadSafety() in examples and test programs

### DIFF
--- a/examples/A01/exampleA01.cxx
+++ b/examples/A01/exampleA01.cxx
@@ -25,8 +25,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -35,8 +34,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/A01/testA01.cxx
+++ b/examples/A01/testA01.cxx
@@ -147,8 +147,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/E01/exampleE01.cxx
+++ b/examples/E01/exampleE01.cxx
@@ -28,8 +28,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -38,8 +37,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application

--- a/examples/E01/testE01.cxx
+++ b/examples/E01/testE01.cxx
@@ -47,9 +47,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
 #include "TROOT.h"
-#include "TThread.h"
 
 #include <iostream>
 #include <string>
@@ -136,8 +134,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/E02/exampleE02.cxx
+++ b/examples/E02/exampleE02.cxx
@@ -24,8 +24,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -34,8 +33,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/E02/testE02.cxx
+++ b/examples/E02/testE02.cxx
@@ -47,9 +47,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
 #include "TROOT.h"
-#include "TThread.h"
 
 #include <iostream>
 #include <string>
@@ -136,8 +134,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/E03/E03a/exampleE03a.cxx
+++ b/examples/E03/E03a/exampleE03a.cxx
@@ -25,8 +25,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -35,8 +34,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/E03/E03a/testE03a.cxx
+++ b/examples/E03/E03a/testE03a.cxx
@@ -51,9 +51,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
 #include "TROOT.h"
-#include "TThread.h"
 
 #include <iostream>
 #include <string>
@@ -147,8 +145,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/E03/E03b/exampleE03b.cxx
+++ b/examples/E03/E03b/exampleE03b.cxx
@@ -25,8 +25,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -35,8 +34,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/E03/E03b/testE03b.cxx
+++ b/examples/E03/E03b/testE03b.cxx
@@ -51,9 +51,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
 #include "TROOT.h"
-#include "TThread.h"
 
 #include <iostream>
 #include <string>
@@ -147,8 +145,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/E03/E03c/exampleE03c.cxx
+++ b/examples/E03/E03c/exampleE03c.cxx
@@ -25,8 +25,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -35,8 +34,7 @@ int main(int argc, char** argv)
 // (Multi-threading is triggered automatically if Geant4 was built
 //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   Bool_t isMulti = false;

--- a/examples/E03/E03c/testE03c.cxx
+++ b/examples/E03/E03c/testE03c.cxx
@@ -52,9 +52,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
 #include "TROOT.h"
-#include "TThread.h"
 
 #include <iostream>
 #include <string>
@@ -201,8 +199,7 @@ int main(int argc, char** argv)
 // (Multi-threading is triggered automatically if Geant4 was built
 //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/E06/exampleE06.cxx
+++ b/examples/E06/exampleE06.cxx
@@ -25,8 +25,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -35,8 +34,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/E06/testE06.cxx
+++ b/examples/E06/testE06.cxx
@@ -144,8 +144,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/ExGarfield/exampleExGarfield.cxx
+++ b/examples/ExGarfield/exampleExGarfield.cxx
@@ -24,8 +24,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -34,8 +33,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/ExGarfield/testExGarfield.cxx
+++ b/examples/ExGarfield/testExGarfield.cxx
@@ -140,8 +140,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/Gflash/exampleGflash.cxx
+++ b/examples/Gflash/exampleGflash.cxx
@@ -24,8 +24,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -34,8 +33,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/Gflash/testGflash.cxx
+++ b/examples/Gflash/testGflash.cxx
@@ -140,8 +140,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/Monopole/exampleMonopole.cxx
+++ b/examples/Monopole/exampleMonopole.cxx
@@ -25,8 +25,7 @@
 #include "TGeant4.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -41,8 +40,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application

--- a/examples/Monopole/testMonopole.cxx
+++ b/examples/Monopole/testMonopole.cxx
@@ -118,8 +118,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments

--- a/examples/TR/exampleTR.cxx
+++ b/examples/TR/exampleTR.cxx
@@ -25,8 +25,7 @@
 #include "TGeant3TGeo.h"
 #endif
 
-#include "TInterpreter.h"
-#include "TThread.h"
+#include "TROOT.h"
 
 /// Application main program
 int main(int argc, char** argv)
@@ -35,8 +34,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Create MC application (thread local)

--- a/examples/TR/testTR.cxx
+++ b/examples/TR/testTR.cxx
@@ -142,8 +142,7 @@ int main(int argc, char** argv)
   // (Multi-threading is triggered automatically if Geant4 was built
   //  in MT mode.)
 #ifdef G4MULTITHREADED
-  TThread::Initialize();
-  gInterpreter->SetProcessLineLock(false);
+  ROOT::EnableThreadSafety();
 #endif
 
   // Process arguments


### PR DESCRIPTION
- Instead of the usage of TThread (now obsolete)
- This fixes runtime error from <TReentrantRWLock::WriteUnLock> that happens for all examples and tests run in Mt from linked executables
- Following suggestions at [ROOT forum thread](https://root-forum.cern.ch/t/error-in-treentrantrwlock-writeunlock-write-lock-already-released-tthread-member-function/43663/1)