### PR TITLE
Improvements and fixes in VMC cuts to ranges conversion

### DIFF
--- a/source/geometry/include/TG4GeometryManager.h
+++ b/source/geometry/include/TG4GeometryManager.h
@@ -32,6 +32,7 @@ class TG4G3ControlVector;
 class TG4VUserRegionConstruction;
 class TG4VUserPostDetConstruction;
 class TG4RadiatorDescription;
+class TG4RootDetectorConstruction;
 
 class G4LogicalVolume;
 class G4EquationOfMotion;
@@ -74,6 +75,9 @@ class TG4GeometryManager : public TG4Verbose
   void SetIsUserMaxStep(G4bool isUserMaxStep);
   void SetIsMaxStepInLowDensityMaterials(G4bool isMaxStep);
 
+  // set Root detector construction
+  void SetRootDetectorConstruction(
+    TG4RootDetectorConstruction* rootDetectorConstruction);
   // set user region construction
   void SetUserRegionConstruction(
     TG4VUserRegionConstruction* userRegionConstruction);
@@ -128,6 +132,7 @@ class TG4GeometryManager : public TG4Verbose
   TG4DetConstructionMessenger fMessenger; ///< messenger
   TG4GeometryServices* fGeometryServices; ///< geometry services
   TVirtualMCGeometry* fMCGeometry;        ///< VirtualMC geometry
+  TG4RootDetectorConstruction* fRootDetectorConstruction; ///< Root detector construction
   TG4OpGeometryManager* fOpManager;       ///< optical geometry manager
 
   /// Fast simulation models manager
@@ -205,6 +210,13 @@ TG4GeometryManager::GetEmModelsManager() const
 {
   /// Return fast simulation models manager
   return fEmModelsManager;
+}
+
+inline void TG4GeometryManager::SetRootDetectorConstruction(
+  TG4RootDetectorConstruction* rootDetectorConstruction)
+{
+  /// Set Root detector construction
+  fRootDetectorConstruction = rootDetectorConstruction;
 }
 
 inline void TG4GeometryManager::SetLimitDensity(G4double density)

--- a/source/geometry/src/TG4GeometryManager.cxx
+++ b/source/geometry/src/TG4GeometryManager.cxx
@@ -507,7 +507,22 @@ void TG4GeometryManager::FillMediumMapFromRoot()
   for (G4int i = 0; i < G4int(lvStore->size()); i++) {
     G4LogicalVolume* lv = (*lvStore)[i];
 
-    TGeoVolume* geoVolume = fRootDetectorConstruction->GetVolume(lv);
+    TGeoVolume* geoVolume = nullptr;
+
+    if (fRootDetectorConstruction == nullptr) {
+      G4String volName = lv->GetName();
+
+      // Filter out the reflected volumes name extension
+      // added by reflection factory
+      G4String ext = G4ReflectionFactory::Instance()->GetVolumesNameExtension();
+      if (volName.find(ext)) volName = volName.substr(0, volName.find(ext));
+
+      geoVolume = gGeoManager->GetVolume(volName.data());
+    }
+    else {
+      geoVolume = fRootDetectorConstruction->GetVolume(lv);
+    }
+
     if (!geoVolume) {
       TG4Globals::Exception("TG4GeometryManager", "FillMediumMapFromRoot",
         "Root volume " + TString(lv->GetName()) + " not found");

--- a/source/geometry/src/TG4PostDetConstruction.cxx
+++ b/source/geometry/src/TG4PostDetConstruction.cxx
@@ -36,12 +36,13 @@ TG4PostDetConstruction::~TG4PostDetConstruction()
 //
 
 //_____________________________________________________________________________
-void TG4PostDetConstruction::Initialize(TG4RootDetectorConstruction* /*dc*/)
+void TG4PostDetConstruction::Initialize(TG4RootDetectorConstruction* dc)
 {
   /// Construct geometry using the VMC application.
   // --
 
   G4cout << "TG4PostDetConstruction::Initialize" << G4endl;
+  TG4GeometryManager::Instance()->SetRootDetectorConstruction(dc);
   TG4GeometryManager::Instance()->ConstructGeometry();
 }
 

--- a/source/run/include/TG4RegionsManager.h
+++ b/source/run/include/TG4RegionsManager.h
@@ -82,7 +82,9 @@ class TG4RegionsManager : public TG4Verbose
   // methods
   void DefineRegions();
   void CheckRegions() const;
-  void PrintRegions() const;
+  void PrintRegions(std::ostream& output) const;
+  void SaveRegions();
+  void LoadRegions();
   void DumpRegion(const G4String& volName) const;
 
   // set methods
@@ -91,8 +93,11 @@ class TG4RegionsManager : public TG4Verbose
   void SetApplyForElectron(G4bool applyForElectron);
   void SetApplyForPositron(G4bool applyForPositron);
   void SetApplyForProton(G4bool applyForProton);
+  void SetFileName(const G4String& fileName);
   void SetCheck(G4bool isCheck);
   void SetPrint(G4bool isPrint);
+  void SetSave(G4bool isSave);
+  void SetLoad(G4bool isLoad);
 
   // get methods
   G4int GetRangePrecision() const;
@@ -100,8 +105,11 @@ class TG4RegionsManager : public TG4Verbose
   G4bool GetApplyForElectron() const;
   G4bool GetApplyForPositron() const;
   G4bool GetApplyForProton() const;
+  G4String GetFileName() const;
   G4bool IsCheck() const;
   G4bool IsPrint() const;
+  G4bool IsSave() const;
+  G4bool IsLoad() const;
 
  private:
   /// Not implemented
@@ -155,6 +163,10 @@ class TG4RegionsManager : public TG4Verbose
   static const G4int fgkMaxRangeOrder;
   /// the name of the region with default cuts
   static const G4String fgkDefaultRegionName;
+  /// the name of the region with default cuts
+  static const G4String fgkDefaultFileName;
+  /// number of values read per region
+  static const size_t fgkNofValues = 6;
 
   //
   // data members
@@ -171,10 +183,18 @@ class TG4RegionsManager : public TG4Verbose
   G4bool fApplyForPositron;
   /// option to apply range cuts for proton (default is true)
   G4bool fApplyForProton;
+  /// file name for regions output
+  G4String fFileName;
   /// option to perform consistency check (by default false)
   G4bool fIsCheck;
   /// option to print all regions
   G4bool fIsPrint;
+  /// option to save all regions in a file
+  G4bool fIsSave;
+  /// option to load regions ranges from a file
+  G4bool fIsLoad;
+  /// map for lodaded ranges
+  std::map<G4String, std::array<G4double, fgkNofValues>> fLoadedRanges;
 };
 
 /// Return the singleton instance
@@ -209,6 +229,12 @@ inline void TG4RegionsManager::SetApplyForPositron(G4bool applyForPositron)
 inline void TG4RegionsManager::SetApplyForProton(G4bool applyForProton)
 {
   fApplyForProton = applyForProton;
+}
+
+/// Set the file name for regions output
+inline void TG4RegionsManager::SetFileName(const G4String& fileName)
+{
+  fFileName = fileName;
 }
 
 /// Set the option to perform consistency check
@@ -247,10 +273,22 @@ inline G4bool TG4RegionsManager::GetApplyForProton() const
   return fApplyForProton;
 }
 
+/// Return the file name for regions output
+inline G4String TG4RegionsManager::GetFileName() const
+{
+  return fFileName;
+}
+
 /// Return the option to perform consistency check
 inline G4bool TG4RegionsManager::IsCheck() const { return fIsCheck; }
 
 /// Return the option to print all regions
 inline G4bool TG4RegionsManager::IsPrint() const { return fIsPrint; }
+
+/// Return option to save all regions in a file
+inline G4bool TG4RegionsManager::IsSave() const { return fIsSave; }
+
+/// Return the option to load regions ranges from a file
+inline G4bool TG4RegionsManager::IsLoad() const { return fIsLoad; }
 
 #endif // TG4_REGIONS_MANAGER_H

--- a/source/run/include/TG4RegionsMessenger.h
+++ b/source/run/include/TG4RegionsMessenger.h
@@ -21,6 +21,7 @@
 class TG4RegionsManager;
 
 class G4UIdirectory;
+class G4UIcmdWithADouble;
 class G4UIcmdWithAString;
 class G4UIcmdWithAnInteger;
 class G4UIcmdWithABool;
@@ -31,6 +32,7 @@ class G4UIcmdWithABool;
 /// Implements commands:
 /// - /mcRegions/dump [lvName]
 /// - /mcRegions/setRangePrecision value
+/// - /mcRegions/setEnergyTolerance value
 /// - /mcRegions/applyForGamma true|false
 /// - /mcRegions/applyForElectron true|false
 /// - /mcRegions/applyForPositron true|false
@@ -39,6 +41,7 @@ class G4UIcmdWithABool;
 /// - /mcRegions/print [true|false]
 /// - /mcRegions/save [true|false]
 /// - /mcRegions/load [true|false]
+/// - /mcRegions/fromG4Table [true|false]
 /// - /mcRegions/setFileName fileName
 ///
 /// \author I. Hrivnacova; IPN, Orsay
@@ -66,8 +69,10 @@ class TG4RegionsMessenger : public G4UImessenger
 
   /// command: /mcRegions/dump [lvName]
   G4UIcmdWithAString* fDumpRegionCmd;
-  /// command: /mcRegions/applyForGamma true|false
+  /// command: /mcRegions/setRangePrecision value
   G4UIcmdWithAnInteger* fSetRangePrecisionCmd;
+  /// command: /mcRegions/setEnergyTolerance value
+  G4UIcmdWithADouble* fSetEnergyToleranceCmd;
   /// command: /mcRegions/applyForGamma true|false
   G4UIcmdWithABool* fApplyForGammaCmd;
   /// command: /mcRegions/applyForElectron true|false
@@ -84,8 +89,12 @@ class TG4RegionsMessenger : public G4UImessenger
   G4UIcmdWithABool* fSetSaveCmd;
   /// command: /mcRegions/load [true|false]
   G4UIcmdWithABool* fSetLoadCmd;
+  /// command: /mcRegions/fromG4Table [true|false]
+  G4UIcmdWithABool* fSetFromG4TableCmd;
   /// command: /mcRegions/setFileName fileName
   G4UIcmdWithAString* fSetFileNameCmd;
+  /// option to activate print/save from production cuts table
+  G4bool fIsFromG4Table;
 };
 
 #endif // TG4_RUN_MESSENGER_H

--- a/source/run/include/TG4RegionsMessenger.h
+++ b/source/run/include/TG4RegionsMessenger.h
@@ -37,6 +37,9 @@ class G4UIcmdWithABool;
 /// - /mcRegions/applyForProton true|false
 /// - /mcRegions/check [true|false]
 /// - /mcRegions/print [true|false]
+/// - /mcRegions/save [true|false]
+/// - /mcRegions/load [true|false]
+/// - /mcRegions/setFileName fileName
 ///
 /// \author I. Hrivnacova; IPN, Orsay
 
@@ -77,6 +80,12 @@ class TG4RegionsMessenger : public G4UImessenger
   G4UIcmdWithABool* fSetCheckCmd;
   /// command: /mcRegions/print [true|false]
   G4UIcmdWithABool* fSetPrintCmd;
+  /// command: /mcRegions/save [true|false]
+  G4UIcmdWithABool* fSetSaveCmd;
+  /// command: /mcRegions/load [true|false]
+  G4UIcmdWithABool* fSetLoadCmd;
+  /// command: /mcRegions/setFileName fileName
+  G4UIcmdWithAString* fSetFileNameCmd;
 };
 
 #endif // TG4_RUN_MESSENGER_H

--- a/source/run/src/TG4RegionsManager.cxx
+++ b/source/run/src/TG4RegionsManager.cxx
@@ -380,7 +380,7 @@ void TG4RegionsManager::CheckRegionsRanges() const
       if (fabs(values[idx] - values[vmcIdx]) >
           (values[vmcIdx] * fEnergyTolerance * factor)) {
 
-        G4cout << std::setw(25) << regionName << "  " << cutType
+        G4cout << std::setw(25) << std::left << regionName << "  " << cutType
                << " cut from range = " << std::scientific << values[idx] / MeV
                << " from limits = " << std::scientific<< values[vmcIdx] / MeV
                << " MeV" << " delta: "

--- a/source/run/src/TG4RegionsManager.cxx
+++ b/source/run/src/TG4RegionsManager.cxx
@@ -133,7 +133,7 @@ G4bool TG4RegionsManager::Iterate(G4double energyCut, G4double& lowerCut,
   G4double step = (higherCut - lowerCut) / nbin;
   energyToRangeMap.clear();
   G4String indent("     ");
-  for (G4int i = 0; i < nbin; i++) {
+  for (G4int i = 0; i <= nbin; i++) {
     G4double rangeCut = lowerCut + i * step;
     if (rangeCut < defaultRangeCut) continue;
     G4double energy = converter.Convert(rangeCut, material);

--- a/source/run/src/TG4RegionsMessenger.cxx
+++ b/source/run/src/TG4RegionsMessenger.cxx
@@ -79,6 +79,22 @@ TG4RegionsMessenger::TG4RegionsMessenger(TG4RegionsManager* runManager)
   fSetPrintCmd->SetGuidance("Switch on|off printing of all regions properties");
   fSetPrintCmd->SetParameterName("IsPrint", false);
   fSetPrintCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fSetSaveCmd = new G4UIcmdWithABool("/mcRegions/save", this);
+  fSetSaveCmd->SetGuidance("Switch on|off saving of all regions properties in a file");
+  fSetSaveCmd->SetParameterName("IsSave", false);
+  fSetSaveCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fSetLoadCmd = new G4UIcmdWithABool("/mcRegions/load", this);
+  fSetLoadCmd->SetGuidance("Switch on|off loading of all regions cuts & ranges from a file");
+  fSetLoadCmd->SetParameterName("IsLoad", false);
+  fSetLoadCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fSetFileNameCmd = new G4UIcmdWithAString("/mcRegions/setFileName", this);
+  fSetFileNameCmd->SetGuidance("Set file name for the regions output");
+  fSetFileNameCmd->SetParameterName("FileName", false);
+  fSetFileNameCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
 }
 
 //_____________________________________________________________________________
@@ -95,6 +111,9 @@ TG4RegionsMessenger::~TG4RegionsMessenger()
   delete fApplyForProtonCmd;
   delete fSetCheckCmd;
   delete fSetPrintCmd;
+  delete fSetSaveCmd;
+  delete fSetLoadCmd;
+  delete fSetFileNameCmd;
 }
 
 //
@@ -134,5 +153,14 @@ void TG4RegionsMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
   }
   else if (command == fSetPrintCmd) {
     fRegionsManager->SetPrint(fSetPrintCmd->GetNewBoolValue(newValue));
+  }
+  else if (command == fSetSaveCmd) {
+    fRegionsManager->SetSave(fSetSaveCmd->GetNewBoolValue(newValue));
+  }
+  else if (command == fSetLoadCmd) {
+    fRegionsManager->SetLoad(fSetPrintCmd->GetNewBoolValue(newValue));
+  }
+  else if (command == fSetFileNameCmd) {
+    fRegionsManager->SetFileName(newValue);
   }
 }

--- a/source/run/src/TG4RunAction.cxx
+++ b/source/run/src/TG4RunAction.cxx
@@ -172,7 +172,10 @@ void TG4RunAction::BeginOfRunAction(const G4Run* run)
       TG4RegionsManager::Instance()->CheckRegions();
     }
     if (TG4RegionsManager::Instance()->IsPrint()) {
-      TG4RegionsManager::Instance()->PrintRegions();
+      TG4RegionsManager::Instance()->PrintRegions(G4cout);
+    }
+    if (TG4RegionsManager::Instance()->IsSave()) {
+      TG4RegionsManager::Instance()->SaveRegions();
     }
   }
 


### PR DESCRIPTION
- Added new functions in TG4RegionsManager for saving/loading region data
- Added `DumpRegionStore()` function to dump all region properties: production cuts, volumes list and material list
- Changed the default value of the energy tolerance for checking regions  to 0.01 and aded a function to set this value
- Added a map for the region data including the computed ranges and energy cuts
- Use new map in CheckRegionsRanges and removed old implementation
- Added an option to print or save region data from the production cuts table or from the map
- Create media according to the G4Root volume map instead of getting TGeoVolume by name (this supports geometries with not unique volume names).
-  New UI commands:
```
  /mcRegions/save [true|false]
  /mcRegions/load [true|false]
  /mcRegions/setFileName fileName
  /mcRegions/setEnergyTolerance value
  /mcRegions/fromG4Table [true|false]
```

Fixes:
- In DefineRegions: skip evaluation of cuts when the production cuts are already defined (this significantly speeds up the procedure)
- Fixed iteration limits in `TG4RegionsManager::Iterate()` - do not skip the last bin
