### PR TITLE
Allow to invoke random seed propagations to Geant4

### DIFF
--- a/source/run/include/TG4RunManager.h
+++ b/source/run/include/TG4RunManager.h
@@ -77,6 +77,8 @@ class TG4RunManager : public TG4Verbose
   void UseG3Defaults();
   void UseRootRandom(G4bool useRootRandom);
 
+  /// picks up random seed from ROOT gRandom and propagates to Geant4
+  void SetRandomSeed();
  private:
   /// Not implemented
   TG4RunManager();
@@ -90,7 +92,6 @@ class TG4RunManager : public TG4Verbose
   void CloneRootNavigatorForWorker();
   void FilterARGV(const G4String& option);
   void CreateRootUI();
-  void SetRandomSeed();
 
   // static data members
 

--- a/source/run/include/TGeant4.h
+++ b/source/run/include/TGeant4.h
@@ -341,6 +341,7 @@ class TGeant4 : public TVirtualMC
   virtual void SetCollectTracks(Bool_t collectTracks);
   virtual Bool_t IsCollectTracks() const;
   virtual Bool_t IsMT() const;
+  void SetRandomSeed(); // set's random seed of engine based on status of ROOT gRandom
 
   // UI control methods
   void StartGeantUI();

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -383,7 +383,7 @@ void TG4RunManager::FilterARGV(const G4String& arg)
 //_____________________________________________________________________________
 void TG4RunManager::SetRandomSeed()
 {
-  /// Pass the random number seed from fRandom to Geant4 random number
+  /// Pass the random number seed from gRandom to Geant4 random number
   /// generator
 
   long seeds[10];

--- a/source/run/src/TGeant4.cxx
+++ b/source/run/src/TGeant4.cxx
@@ -1329,3 +1329,7 @@ void TGeant4::InitLego()
 
   TG4Globals::Warning("TGeant4", "InitLego", "Not implemented.");
 }
+//_____________________________________________________________________________
+void TGeant4::SetRandomSeed() {
+  fRunManager->SetRandomSeed();
+}


### PR DESCRIPTION
So far, we can only propagate or pick up the seed
from gRandom to Geant4 (CLHEP) during initialization.

This commit makes minimal changes that allows an expert user to call TG4RunManager::SetRandomSeed() at any moment, thereby gaining better control over the random state of the Geant4 engine.

Motivation:

In the multi-process + sub-event parallel framework of ALICE, we are in the need of an interface that allows us to set the random state during simulation runs, in order to
ensure total reproducibility of our simulations with Geant4 when starting from the same initial seed. For Geant3, this was already working but reproducibility was so far lacking for Geant4.

The present change (or similar) is also need for the even higher goal of "track seeding", which gives reproducible simulations on the track level even when cuts or geometry change in some parts of the detector.