### PR TITLE
Fix in Gmtod, Gdtom:

### DIFF
--- a/source/digits+hits/src/TG4StepManager.cxx
+++ b/source/digits+hits/src/TG4StepManager.cxx
@@ -590,12 +590,12 @@ void TG4StepManager::Gmtod(Float_t* xm, Float_t* xd, Int_t iflag)
   ///
 
   G4double* dxm = TG4GeometryServices::Instance()->CreateG4doubleArray(xm, 3);
-  G4double* dxd = TG4GeometryServices::Instance()->CreateG4doubleArray(xd, 3);
+  G4double* dxd = TG4GeometryServices::Instance()->CreateG4doubleArray(xd, 3, false);
 
   Gmtod(dxm, dxd, iflag);
 
+  // Fill computed xd coordinates
   for (G4int i = 0; i < 3; i++) {
-    xm[i] = dxm[i];
     xd[i] = dxd[i];
   }
 
@@ -655,12 +655,12 @@ void TG4StepManager::Gdtom(Float_t* xd, Float_t* xm, Int_t iflag)
   ///              - IFLAG=2  convert direction cosinus
 
   G4double* dxd = TG4GeometryServices::Instance()->CreateG4doubleArray(xd, 3);
-  G4double* dxm = TG4GeometryServices::Instance()->CreateG4doubleArray(xm, 3);
+  G4double* dxm = TG4GeometryServices::Instance()->CreateG4doubleArray(xm, 3, false);
 
   Gdtom(dxd, dxm, iflag);
 
+  // Fill computed xm coordinates
   for (G4int i = 0; i < 3; i++) {
-    xd[i] = dxd[i];
     xm[i] = dxm[i];
   }
 

--- a/source/geometry/include/TG4GeometryServices.h
+++ b/source/geometry/include/TG4GeometryServices.h
@@ -64,8 +64,8 @@ class TG4GeometryServices : public TG4Verbose
 
   // methods
   // utilities
-  G4double* CreateG4doubleArray(Float_t* array, G4int size) const;
-  G4double* CreateG4doubleArray(Double_t* array, G4int size) const;
+  G4double* CreateG4doubleArray(Float_t* array, G4int size, G4bool copyValues = true) const;
+  G4double* CreateG4doubleArray(Double_t* array, G4int size, G4bool copyValues = true) const;
   G4String CutName(const char* name) const;
   G4String CutMaterialName(const char* name) const;
   G4String CutVolumePath(

--- a/source/geometry/src/TG4GeometryServices.cxx
+++ b/source/geometry/src/TG4GeometryServices.cxx
@@ -204,7 +204,7 @@ G4double* TG4GeometryServices::ConvertAtomWeight(
 
 //_____________________________________________________________________________
 G4double* TG4GeometryServices::CreateG4doubleArray(
-  Float_t* array, G4int size) const
+  Float_t* array, G4int size, G4bool copyValues) const
 {
   /// Convert Float_t* array to G4double*.                                    \n
   /// !! The new array has to be deleted by user.
@@ -212,7 +212,9 @@ G4double* TG4GeometryServices::CreateG4doubleArray(
   G4double* doubleArray;
   if (size > 0) {
     doubleArray = new G4double[size];
-    for (G4int i = 0; i < size; i++) doubleArray[i] = array[i];
+    if (copyValues) {
+      for (G4int i = 0; i < size; i++) doubleArray[i] = array[i];
+    }
   }
   else {
     doubleArray = 0;
@@ -222,7 +224,7 @@ G4double* TG4GeometryServices::CreateG4doubleArray(
 
 //_____________________________________________________________________________
 G4double* TG4GeometryServices::CreateG4doubleArray(
-  Double_t* array, G4int size) const
+  Double_t* array, G4int size, G4bool copyValues) const
 {
   /// Copy Double_t* array to G4double*.                                    \n
   /// !! The new array has to be deleted by user.
@@ -230,7 +232,9 @@ G4double* TG4GeometryServices::CreateG4doubleArray(
   G4double* doubleArray;
   if (size > 0) {
     doubleArray = new G4double[size];
-    for (G4int i = 0; i < size; i++) doubleArray[i] = array[i];
+    if (copyValues) {
+      for (G4int i = 0; i < size; i++) doubleArray[i] = array[i];
+    }
   }
   else {
     doubleArray = 0;


### PR DESCRIPTION
- Do not copy array values when converting in a double array for the arrays passed for output
- This should prevent from break if users pass unitialized arrays