### PR TITLE
Improvements for (cached) magnetic fields + cleanup (#49)

### DIFF
--- a/source/geometry/include/TG4Field.h
+++ b/source/geometry/include/TG4Field.h
@@ -53,8 +53,6 @@ class TG4Field
 
   virtual void Update(const TG4FieldParameters& parameters);
 
-  virtual void PrintStatistics() const {}
-
   // access to field setting
   G4Field* GetG4Field() const;
   G4EquationOfMotion* GetEquation() const;

--- a/source/geometry/src/TG4CachedMagneticField.cxx
+++ b/source/geometry/src/TG4CachedMagneticField.cxx
@@ -62,8 +62,8 @@ void TG4CachedMagneticField::GetFieldValue(
 
   // New evaluation
   // Set units
-  const G4double g3point[3] = { point[0] / TG4G3Units::Length(),
-    point[1] / TG4G3Units::Length(), point[2] / TG4G3Units::Length() };
+  const G4double g3point[3] = { point[0] * TG4G3Units::InverseLength(),
+    point[1] * TG4G3Units::InverseLength(), point[2] * TG4G3Units::InverseLength() };
 
   // Call user field
   fVirtualMagField->Field(g3point, bfield);
@@ -94,9 +94,8 @@ void TG4CachedMagneticField::GetFieldValue(
 void TG4CachedMagneticField::PrintStatistics() const
 {
   /// Print the caching statistics
-
   if (fConstDistanceSquare) {
-    G4cout << " Cached field: " << G4endl
+    G4cout << "TG4CachedMagneticField: " << G4endl
            << "   Number of calls:        " << fCallsCounter << G4endl
            << "   Number of evaluations : " << fEvaluationsCounter << G4endl;
   }
@@ -106,7 +105,6 @@ void TG4CachedMagneticField::PrintStatistics() const
 void TG4CachedMagneticField::SetConstDistance(G4double value)
 {
   /// Set new const distance value
-
   fConstDistanceSquare = value * value;
 }
 
@@ -114,7 +112,6 @@ void TG4CachedMagneticField::SetConstDistance(G4double value)
 void TG4CachedMagneticField::ClearCounter()
 {
   /// Clear counters
-
   fCallsCounter = 0;
   fEvaluationsCounter = 0;
 }

--- a/source/geometry/src/TG4GeometryManager.cxx
+++ b/source/geometry/src/TG4GeometryManager.cxx
@@ -15,6 +15,7 @@
 #include "TG4GeometryManager.h"
 #include "TG4BiasingManager.h"
 #include "TG4Field.h"
+#include "TG4MagneticField.h"
 #include "TG4FieldParameters.h"
 #include "TG4G3ControlVector.h"
 #include "TG4G3CutVector.h"
@@ -1084,11 +1085,15 @@ void TG4GeometryManager::SetUserStepper(
 void TG4GeometryManager::PrintFieldStatistics() const
 {
   /// Print field statistics.
-  /// Currently only cached field print the cahching statistics.
-
+  /// Currently only the cached field prints the caching statistics.
   if (VerboseLevel() > 0 && fgFields) {
     for (G4int i = 0; i < G4int(fgFields->size()); ++i) {
-      fgFields->at(i)->PrintStatistics();
+      auto f = fgFields->at(i); // this is a TG4Field
+      // we need to get the containing TG4MagneticField in order to print statistics
+      auto mgfield = dynamic_cast<TG4MagneticField*>(f->GetG4Field());
+      if (mgfield) {
+        mgfield->PrintStatistics();
+      }
     }
   }
 }

--- a/source/geometry/src/TG4MagneticField.cxx
+++ b/source/geometry/src/TG4MagneticField.cxx
@@ -41,8 +41,8 @@ void TG4MagneticField::GetFieldValue(
   /// Return the bfield values in the given point.
 
   // Set units
-  const G4double g3point[3] = { point[0] / TG4G3Units::Length(),
-    point[1] / TG4G3Units::Length(), point[2] / TG4G3Units::Length() };
+  const G4double g3point[3] = { point[0] * TG4G3Units::InverseLength(),
+    point[1] * TG4G3Units::InverseLength(), point[2] * TG4G3Units::InverseLength() };
 
   // Call user field
   fVirtualMagField->Field(g3point, bfield);

--- a/source/global/include/TG4G3Units.h
+++ b/source/global/include/TG4G3Units.h
@@ -27,10 +27,11 @@
 class TG4G3Units
 {
  public:
-  virtual ~TG4G3Units();
+  ~TG4G3Units();
 
   // static get methods
   static G4double Length();
+  static G4double InverseLength();
   static G4double Angle();
   static G4double Time();
   static G4double Charge();
@@ -45,6 +46,7 @@ class TG4G3Units
 
   // static data members
   static const G4double fgkLength;       ///< G3 length unit
+  static const G4double fgkInverseLength;///< 1 over G3 length unit
   static const G4double fgkAngle;        ///< G3 angle unit
   static const G4double fgkTime;         ///< G3 time unit
   static const G4double fgkCharge;       ///< G3 charge unit
@@ -61,6 +63,10 @@ inline G4double TG4G3Units::Length()
 {
   /// Return G3 length unit
   return fgkLength;
+}
+
+inline G4double TG4G3Units::InverseLength() {
+  return fgkInverseLength;
 }
 
 inline G4double TG4G3Units::Angle()

--- a/source/global/src/TG4G3Units.cxx
+++ b/source/global/src/TG4G3Units.cxx
@@ -27,6 +27,7 @@ const G4double TG4G3Units::fgkMass = GeV;
 const G4double TG4G3Units::fgkMassDensity = g / cm3;
 const G4double TG4G3Units::fgkAtomicWeight = g / mole;
 const G4double TG4G3Units::fgkField = kilogauss;
+const G4double TG4G3Units::fgkInverseLength = 1. / cm;
 
 //_____________________________________________________________________________
 TG4G3Units::~TG4G3Units()


### PR DESCRIPTION
This commit is proposing the following changes:

a) Avoid divisions in functions that are called often
   from the G4 engine (when this is possible).
   This is in particular true for TG4CachedMagnetic field
   evaluation which is on top of the perf profile (so it makes sense to incrementally
   improve this function).
   Replacing divisions by multiplications avoids pipeline stalls. The concrete
   effect depends on the ratio of cache acceptance to field evaluations but
   no harm is in any case done.

b) fix the dispatch to PrintStatistics from TG4GeometryManager.
   The dispatch was to TG4Field and not to TG4MagneticField, and
   in result the statistics from TG4CachedMagneticField was never shown.

c) other smaller cleanups (remove virtual keyword when not necessary,...)