### PR TITLE
Implemented productions cuts per energy, updated E03 and more ...

### DIFF
--- a/examples/E03/E03a/src/Ex03DetectorConstruction.cxx
+++ b/examples/E03/E03a/src/Ex03DetectorConstruction.cxx
@@ -407,10 +407,18 @@ void Ex03DetectorConstruction::SetCuts()
     // set VMC cutes for the medium
     Int_t mediumId = gMC->MediumId(materialCuts.fName);
     if (mediumId) {
-      gMC->Gstpar(mediumId, "CUTGAM", materialCuts.fCUTGAM);
-      gMC->Gstpar(mediumId, "BCUTE", materialCuts.fBCUTE);
-      gMC->Gstpar(mediumId, "CUTELE", materialCuts.fCUTELE);
-      gMC->Gstpar(mediumId, "DCUTE", materialCuts.fDCUTE);
+      // Set cuts as defined in the vector
+      // gMC->Gstpar(mediumId, "CUTGAM", materialCuts.fCUTGAM);
+      // gMC->Gstpar(mediumId, "BCUTE", materialCuts.fBCUTE);
+      // gMC->Gstpar(mediumId, "CUTELE", materialCuts.fCUTELE);
+      // gMC->Gstpar(mediumId, "DCUTE", materialCuts.fDCUTE);
+      //
+      // Set 100 keV cut everywhere
+      Double_t cut = 100.e-06;
+      gMC->Gstpar(mediumId, "CUTGAM", cut);
+      gMC->Gstpar(mediumId, "BCUTE", cut);
+      gMC->Gstpar(mediumId, "CUTELE", cut);
+      gMC->Gstpar(mediumId, "DCUTE", cut);
     }
   }
 }

--- a/examples/E03/E03b/src/Ex03DetectorConstruction.cxx
+++ b/examples/E03/E03b/src/Ex03DetectorConstruction.cxx
@@ -407,10 +407,18 @@ void Ex03DetectorConstruction::SetCuts()
     // set VMC cutes for the medium
     Int_t mediumId = gMC->MediumId(materialCuts.fName);
     if (mediumId) {
-      gMC->Gstpar(mediumId, "CUTGAM", materialCuts.fCUTGAM);
-      gMC->Gstpar(mediumId, "BCUTE", materialCuts.fBCUTE);
-      gMC->Gstpar(mediumId, "CUTELE", materialCuts.fCUTELE);
-      gMC->Gstpar(mediumId, "DCUTE", materialCuts.fDCUTE);
+      // Set cuts as defined in the vector
+      // gMC->Gstpar(mediumId, "CUTGAM", materialCuts.fCUTGAM);
+      // gMC->Gstpar(mediumId, "BCUTE", materialCuts.fBCUTE);
+      // gMC->Gstpar(mediumId, "CUTELE", materialCuts.fCUTELE);
+      // gMC->Gstpar(mediumId, "DCUTE", materialCuts.fDCUTE);
+      //
+      // Set 100 keV cut everywhere
+      Double_t cut = 100.e-06;
+      gMC->Gstpar(mediumId, "CUTGAM", cut);
+      gMC->Gstpar(mediumId, "BCUTE", cut);
+      gMC->Gstpar(mediumId, "CUTELE", cut);
+      gMC->Gstpar(mediumId, "DCUTE", cut);
     }
   }
 }

--- a/examples/E03/E03c/src/Ex03cDetectorConstruction.cxx
+++ b/examples/E03/E03c/src/Ex03cDetectorConstruction.cxx
@@ -410,10 +410,18 @@ void Ex03cDetectorConstruction::SetCuts()
     // set VMC cutes for the medium
     Int_t mediumId = fMC->MediumId(materialCuts.fName);
     if (mediumId) {
-      fMC->Gstpar(mediumId, "CUTGAM", materialCuts.fCUTGAM);
-      fMC->Gstpar(mediumId, "BCUTE", materialCuts.fBCUTE);
-      fMC->Gstpar(mediumId, "CUTELE", materialCuts.fCUTELE);
-      fMC->Gstpar(mediumId, "DCUTE", materialCuts.fDCUTE);
+      // Set cuts as defined in the vector
+      // gMC->Gstpar(mediumId, "CUTGAM", materialCuts.fCUTGAM);
+      // gMC->Gstpar(mediumId, "BCUTE", materialCuts.fBCUTE);
+      // gMC->Gstpar(mediumId, "CUTELE", materialCuts.fCUTELE);
+      // gMC->Gstpar(mediumId, "DCUTE", materialCuts.fDCUTE);
+      //
+      // Set 100 keV cut everywhere
+      Double_t cut = 100.e-06;
+      gMC->Gstpar(mediumId, "CUTGAM", cut);
+      gMC->Gstpar(mediumId, "BCUTE", cut);
+      gMC->Gstpar(mediumId, "CUTELE", cut);
+      gMC->Gstpar(mediumId, "DCUTE", cut);
     }
   }
 }

--- a/examples/E03/g4Config4.C
+++ b/examples/E03/g4Config4.C
@@ -24,6 +24,10 @@ void Config()
      = new TG4RunConfiguration("geomRootToGeant4", "FTFP_BERT",
                                "specialCuts+specialControls");
 
+  // Activate usage of old regions manager
+  // that sets production thresholds by ranges
+  // runConfiguration->SetSpecialCutsOld(true);
+
   // TGeant4
   TGeant4* geant4
     = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);

--- a/examples/E03/g4config.in
+++ b/examples/E03/g4config.in
@@ -18,6 +18,7 @@
 /mcVerbose/composedPhysicsList 1
 #/mcVerbose/trackManager 2
 #/mcVerbose/geometryManager 2
+#/mcVerbose/regionsManager 2
 
 /control/cout/ignoreThreadsExcept 0
 
@@ -25,3 +26,10 @@
 #/mcPrimaryGenerator/skipUnknownParticles true
 
 #/tracking/verbose 1
+
+/mcPhysics/rangeCuts 0.01 mm
+
+#/mcRegions/check true
+#/mcRegions/print true
+#/mcRegions/save true
+#/mcRegions/setFileName regions2.dat

--- a/examples/E03/g4tgeoConfig4.C
+++ b/examples/E03/g4tgeoConfig4.C
@@ -24,6 +24,10 @@ void Config()
      = new TG4RunConfiguration("geomRoot", "FTFP_BERT",
                                "specialCuts+specialControls");
 
+  // Activate usage of old regions manager
+  // that sets production thresholds by ranges
+  // runConfiguration->SetSpecialCutsOld(true);
+
   // TGeant4
   TGeant4* geant4
     = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);

--- a/examples/E03/g4tgeoConfig4Seq.C
+++ b/examples/E03/g4tgeoConfig4Seq.C
@@ -25,6 +25,10 @@ void Config()
      = new TG4RunConfiguration("geomRoot", "FTFP_BERT",
                                "specialCuts+specialControls", false, false);
 
+  // Activate usage of old regions manager
+  // that sets production thresholds by ranges
+  // runConfiguration->SetSpecialCutsOld(true);
+
   // TGeant4
   TGeant4* geant4
     = new TGeant4("TGeant4", "The Geant4 Monte Carlo", runConfiguration);

--- a/examples/E03/test_E03_5.C
+++ b/examples/E03/test_E03_5.C
@@ -13,7 +13,7 @@
 ///
 /// Running Example03
 
-void test_E03_5(const TString& configMacro, Bool_t oldGeometry)
+void test_E03_5(const TString& configMacro = "g4Config4.C", Bool_t oldGeometry = kFALSE)
 {
 /// Macro function for testing example E03
 /// \param configMacro  configuration macro loaded in initialization
@@ -42,6 +42,7 @@ void test_E03_5(const TString& configMacro, Bool_t oldGeometry)
   appl->SetOldGeometry(oldGeometry);
 
   appl->InitMC(configMacro);
+
   appl->RunMC(1);
 
   if ( needDelete ) delete appl;

--- a/examples/E03/test_E03_6.C
+++ b/examples/E03/test_E03_6.C
@@ -16,7 +16,7 @@
 // Activate this code to check curving of trajectories in field
 //#include "set_vis.C"
 
-void test_E03_6(const TString& configMacro, Bool_t oldGeometry)
+void test_E03_6(const TString& configMacro = "g4Config5.C", Bool_t oldGeometry = kFALSE)
 {
 /// Macro function for testing example E03
 /// \param configMacro  configuration macro loaded in initialization

--- a/source/geometry/src/TG4GeometryManager.cxx
+++ b/source/geometry/src/TG4GeometryManager.cxx
@@ -672,7 +672,7 @@ void TG4GeometryManager::ConstructZeroFields()
 
     // Skip volumes with ifield != 0
     if (medium->GetIfield() != 0) {
-      if (VerboseLevel() > 1) {
+      if (VerboseLevel() > 2) {
         G4cout << "Global field in logical volume: " << lv->GetName() << G4endl;
       }
       continue;

--- a/source/physics/src/TG4PhysicsManager.cxx
+++ b/source/physics/src/TG4PhysicsManager.cxx
@@ -53,7 +53,7 @@
 #include <G4SystemOfUnits.hh>
 
 TG4PhysicsManager* TG4PhysicsManager::fgInstance = 0;
-const G4double TG4PhysicsManager::fgkDefautCut = 1 * mm;
+const G4double TG4PhysicsManager::fgkDefautCut = 1. * mm;
 TG4ProcessMap* TG4PhysicsManager::fgProcessMap = 0;
 
 //_____________________________________________________________________________

--- a/source/run/include/TG4RegionsManager2.h
+++ b/source/run/include/TG4RegionsManager2.h
@@ -1,0 +1,71 @@
+#ifndef TG4_REGIONS_MANAGER2_H
+#define TG4_REGIONS_MANAGER2_H
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2007 - 2023 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TG4RegionsManager2.h
+/// \brief Definition of the TG4RegionsManager2 class
+///
+/// \author I. Hrivnacova; IJCLab Orsay
+
+#include "TG4VRegionsManager.h"
+
+#include <globals.hh>
+
+class TG4Limits;
+
+class G4Region;
+class G4Material;
+class G4MaterialCutsCouple;
+
+/// \ingroup run
+/// \brief Manager class for setting VMC cuts in energy in G4 regions
+///
+/// The VMC cuts in energy can be defined via the following TVirtulaMC
+/// functions:
+/// - TVirtualMC::SetCut(..)
+/// - TVirtualMC::Gstpar(..)
+///
+/// The TG4RegionsManager2 class defines regions with production
+/// cuts corresponding to the VMC energy cuts set by user in two
+/// steps:
+/// - DefineRegions: regions per material are created and applied 
+///   to all logical volumes
+/// - UpdateProductionCutsTable: create material cuts couples in
+///   G4ProductionCutsTable and construct energy cuts vectors in the order 
+///   of created material cuts couples and set them to the table
+///
+/// User can select several levels of verbosity; the following information
+/// is then printed:
+/// - 0  no output
+/// - 1  number of regions added via VMC
+/// - 2  the list of all volumes and their associated regions
+///
+/// \author I. Hrivnacova; IJCLab Orsay
+
+class TG4RegionsManager2 : public TG4VRegionsManager
+{
+ public:
+  TG4RegionsManager2();
+  ~TG4RegionsManager2() override = default;
+
+  // methods
+  void DefineRegions() override;
+  void UpdateProductionCutsTable() override;
+
+ private:
+  TG4RegionsManager2(const TG4RegionsManager2& right) = delete;
+  TG4RegionsManager2& operator=(const TG4RegionsManager2& right) = delete;
+
+  /// messenger
+  TG4RegionsMessenger fMessenger;
+};
+
+#endif // TG4_REGIONS_MANAGER2_H

--- a/source/run/include/TG4RegionsMessenger.h
+++ b/source/run/include/TG4RegionsMessenger.h
@@ -19,6 +19,7 @@
 #include <globals.hh>
 
 class TG4RegionsManager;
+class TG4RegionsManager2;
 
 class G4UIdirectory;
 class G4UIcmdWithADouble;
@@ -27,74 +28,79 @@ class G4UIcmdWithAnInteger;
 class G4UIcmdWithABool;
 
 /// \ingroup run
-/// \brief Messenger class that defines commands for TG4RegionsManager
+/// \brief Messenger class that defines commands for TG4RegionsManager[2]
+///      
 ///
 /// Implements commands:
-/// - /mcRegions/dump [lvName]
+/// - /mcRegions/check [true|false]
+/// - /mcRegions/print [true|false]
+/// - /mcRegions/save [true|false]
+/// - /mcRegions/setFileName fileName
+///
+/// Commands working only with old region manager:
+/// - /mcRegions/dump lvName
 /// - /mcRegions/setRangePrecision value
 /// - /mcRegions/setEnergyTolerance value
 /// - /mcRegions/applyForGamma true|false
 /// - /mcRegions/applyForElectron true|false
 /// - /mcRegions/applyForPositron true|false
 /// - /mcRegions/applyForProton true|false
-/// - /mcRegions/check [true|false]
-/// - /mcRegions/print [true|false]
-/// - /mcRegions/save [true|false]
 /// - /mcRegions/load [true|false]
 /// - /mcRegions/fromG4Table [true|false]
-/// - /mcRegions/setFileName fileName
 ///
 /// \author I. Hrivnacova; IPN, Orsay
 
 class TG4RegionsMessenger : public G4UImessenger
 {
  public:
-  TG4RegionsMessenger(TG4RegionsManager* runManager);
+  TG4RegionsMessenger(TG4RegionsManager* regionsManager);
+  TG4RegionsMessenger(TG4RegionsManager2* regionsManager);
   virtual ~TG4RegionsMessenger();
 
   // methods
   virtual void SetNewValue(G4UIcommand* command, G4String string);
 
  private:
-  /// Not implemented
-  TG4RegionsMessenger();
-  /// Not implemented
-  TG4RegionsMessenger(const TG4RegionsMessenger& right);
-  /// Not implemented
-  TG4RegionsMessenger& operator=(const TG4RegionsMessenger& right);
+  TG4RegionsMessenger() = delete;
+  TG4RegionsMessenger(const TG4RegionsMessenger& right) = delete;
+  TG4RegionsMessenger& operator=(const TG4RegionsMessenger& right) = delete;
+
+  // methods
+  void CreateCommands();
 
   // data members
-  TG4RegionsManager* fRegionsManager; ///< associated class
-  G4UIdirectory* fDirectory;          ///< command directory
+  TG4RegionsManager* fRegionsManager = nullptr;  ///< associated class
+  TG4RegionsManager2* fRegionsManager2 = nullptr; ///< associated class
+  G4UIdirectory* fDirectory = nullptr;          ///< command directory
 
-  /// command: /mcRegions/dump [lvName]
-  G4UIcmdWithAString* fDumpRegionCmd;
-  /// command: /mcRegions/setRangePrecision value
-  G4UIcmdWithAnInteger* fSetRangePrecisionCmd;
-  /// command: /mcRegions/setEnergyTolerance value
-  G4UIcmdWithADouble* fSetEnergyToleranceCmd;
-  /// command: /mcRegions/applyForGamma true|false
-  G4UIcmdWithABool* fApplyForGammaCmd;
-  /// command: /mcRegions/applyForElectron true|false
-  G4UIcmdWithABool* fApplyForElectronCmd;
-  /// command: /mcRegions/applyForPositron true|false
-  G4UIcmdWithABool* fApplyForPositronCmd;
-  /// command: /mcRegions/applyForProton true|false
-  G4UIcmdWithABool* fApplyForProtonCmd;
   /// command: /mcRegions/check [true|false]
-  G4UIcmdWithABool* fSetCheckCmd;
+  G4UIcmdWithABool* fSetCheckCmd = nullptr;
   /// command: /mcRegions/print [true|false]
-  G4UIcmdWithABool* fSetPrintCmd;
+  G4UIcmdWithABool* fSetPrintCmd = nullptr;
   /// command: /mcRegions/save [true|false]
-  G4UIcmdWithABool* fSetSaveCmd;
-  /// command: /mcRegions/load [true|false]
-  G4UIcmdWithABool* fSetLoadCmd;
-  /// command: /mcRegions/fromG4Table [true|false]
-  G4UIcmdWithABool* fSetFromG4TableCmd;
+  G4UIcmdWithABool* fSetSaveCmd = nullptr;
   /// command: /mcRegions/setFileName fileName
-  G4UIcmdWithAString* fSetFileNameCmd;
-  /// option to activate print/save from production cuts table
-  G4bool fIsFromG4Table;
+  G4UIcmdWithAString* fSetFileNameCmd = nullptr;
+
+  // commands working only with old regions messenger
+  /// command: /mcRegions/dump [lvName]
+  G4UIcmdWithAString* fDumpRegionCmd = nullptr;
+  /// command: /mcRegions/setRangePrecision value
+  G4UIcmdWithAnInteger* fSetRangePrecisionCmd = nullptr;
+  /// command: /mcRegions/setEnergyTolerance value
+  G4UIcmdWithADouble* fSetEnergyToleranceCmd = nullptr;
+  /// command: /mcRegions/applyForGamma true|false
+  G4UIcmdWithABool* fApplyForGammaCmd = nullptr;
+  /// command: /mcRegions/applyForElectron true|false
+  G4UIcmdWithABool* fApplyForElectronCmd = nullptr;
+  /// command: /mcRegions/applyForPositron true|false
+  G4UIcmdWithABool* fApplyForPositronCmd = nullptr;
+  /// command: /mcRegions/applyForProton true|false
+  G4UIcmdWithABool* fApplyForProtonCmd = nullptr;
+  /// command: /mcRegions/load [true|false]
+  G4UIcmdWithABool* fSetLoadCmd = nullptr;
+  /// command: /mcRegions/fromG4Table [true|false]
+  G4UIcmdWithABool* fSetFromG4TableCmd = nullptr;
 };
 
 #endif // TG4_RUN_MESSENGER_H

--- a/source/run/include/TG4RunConfiguration.h
+++ b/source/run/include/TG4RunConfiguration.h
@@ -101,6 +101,7 @@ class TG4RunConfiguration
   // set methods
   void SetMTApplication(Bool_t mtApplication);
   void SetParameter(const TString& name, Double_t value);
+  void SetSpecialCutsOld();
 
   // get methods
   TString GetUserGeometry() const;
@@ -108,6 +109,7 @@ class TG4RunConfiguration
   Bool_t IsSpecialStacking() const;
   Bool_t IsSpecialControls() const;
   Bool_t IsSpecialCuts() const;
+  Bool_t IsSpecialCutsOld() const;
   Bool_t IsMTApplication() const;
 
  protected:
@@ -119,6 +121,7 @@ class TG4RunConfiguration
   Bool_t fMTApplication;            ///< option for MT mode if available
   Bool_t fSpecialControls;          ///< option for special controls
   Bool_t fSpecialCuts;              ///< option for special cuts
+  Bool_t fSpecialCutsOld;           ///< option for special cuts old
   G4UImessenger* fAGDDMessenger;    //!< XML messenger
   G4UImessenger* fGDMLMessenger;    //!< XML messenger
 
@@ -138,9 +141,9 @@ class TG4RunConfiguration
 
 // inline functions
 
+/// Return physics list selection
 inline TString TG4RunConfiguration::GetPhysicsListSelection() const
-{
-  /// Return physics list selection
+{ 
   return fPhysicsListSelection;
 }
 

--- a/source/run/include/TG4RunManager.h
+++ b/source/run/include/TG4RunManager.h
@@ -24,7 +24,7 @@
 
 class TG4RunConfiguration;
 class TG4SpecialControlsV2;
-class TG4RegionsManager;
+class TG4VRegionsManager;
 
 class G4RunManager;
 class G4UIExecutive;
@@ -105,7 +105,7 @@ class TG4RunManager : public TG4Verbose
   G4RunManager* fRunManager;              ///< G4RunManager
   TG4RunMessenger fMessenger;             ///< messenger
   TG4RunConfiguration* fRunConfiguration; ///< TG4RunConfiguration
-  TG4RegionsManager* fRegionsManager;     ///< regions manager
+  TG4VRegionsManager* fRegionsManager;    ///< regions manager
   G4UIExecutive* fGeantUISession;         ///< G4 UI
   TApplication* fRootUISession;           ///< Root UI
   G4bool fRootUIOwner;                    ///< ownership of Root UI

--- a/source/run/include/TG4VRegionsManager.h
+++ b/source/run/include/TG4VRegionsManager.h
@@ -1,0 +1,149 @@
+#ifndef TG4_V_REGIONS_MANAGER_H
+#define TG4_V_REGIONS_MANAGER_H
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2007 - 2023 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TG4VRegionsManager.h
+/// \brief Definition of the TG4VRegionsManager class
+///
+/// \author I. Hrivnacova; IJCLab Orsay
+
+#include "TG4G3Cut.h"
+#include "TG4RegionsMessenger.h"
+#include "TG4Verbose.h"
+
+#include <globals.hh>
+
+#include <map>
+
+class TG4Limits;
+
+class G4Region;
+class G4Material;
+class G4VRangeToEnergyConverter;
+class G4MaterialCutsCouple;
+
+/// \ingroup run
+/// \brief Base class for mangers for converting VMC cuts in energy in G4 regions
+///
+/// \author I. Hrivnacova; IPN Orsay
+
+class TG4VRegionsManager : public TG4Verbose
+{
+ public:
+  TG4VRegionsManager();
+  virtual ~TG4VRegionsManager();
+
+  static TG4VRegionsManager* Instance();
+
+  // methods
+  virtual void DefineRegions() = 0;
+  virtual void UpdateProductionCutsTable() = 0;
+
+  virtual void CheckRegions() const;
+  virtual void PrintRegions(std::ostream& output) const;
+  virtual void SaveRegions();
+  virtual void DumpRegionStore() const;
+
+  // set methods
+  void SetFileName(const G4String& fileName);
+  void SetCheck(G4bool isCheck);
+  void SetPrint(G4bool isPrint);
+  void SetSave(G4bool isSave);
+
+  // get methods
+  G4String GetFileName() const;
+  G4bool IsCheck() const;
+  G4bool IsPrint() const;
+  G4bool IsSave() const;
+
+ protected:
+  // constants
+  static constexpr size_t fgkRangeGamIdx = 0;
+  static constexpr size_t fgkRangeEleIdx = 1;
+  static constexpr size_t fgkCutGamIdx = 2;
+  static constexpr size_t fgkCutEleIdx = 3;
+  static constexpr size_t fgkVmcCutGamIdx = 4;
+  static constexpr size_t fgkVmcCutEleIdx = 5;
+  static constexpr size_t fgkValuesSize = 6;
+
+  using TG4RegionData = std::array<G4double, fgkValuesSize>;
+
+  TG4VRegionsManager(const TG4VRegionsManager& right) = delete;
+  TG4VRegionsManager& operator=(const TG4VRegionsManager& right) = delete;
+
+  // methods
+  G4double GetGlobalEnergyCut(TG4G3Cut cutType) const;
+
+  G4double GetEnergyCut(
+    TG4Limits* limits, TG4G3Cut cutType, G4double globalCutValue) const;
+
+  G4bool IsCoupleUsedInTheRegion(
+    const G4MaterialCutsCouple* couple, const G4Region* region) const;
+
+  void CheckRegionsInGeometry() const;
+  void PrintLegend(std::ostream& output) const;
+  void PrintRegionData(std::ostream& output, const G4String& matName,
+    const TG4RegionData& values) const;
+  void PrintFromG4Table(std::ostream& output) const;
+
+  //
+  // static data members
+
+  /// the singleton instance
+  static TG4VRegionsManager* fgInstance;
+  /// the name of the region with default cuts
+  static const G4String fgkDefaultRegionName;
+  /// the name of the region with default cuts
+  static const G4String fgkDefaultFileName;
+
+  //
+  // data members
+
+  /// file name for regions output
+  G4String fFileName;
+  /// option to perform consistency check (by default false)
+  G4bool fIsCheck = false;
+  /// option to print all regions
+  G4bool fIsPrint = false;;
+  /// option to save all regions in a file
+  G4bool fIsSave = false;;
+};
+
+/// Return the singleton instance
+inline TG4VRegionsManager* TG4VRegionsManager::Instance() { return fgInstance; }
+
+/// Set the file name for regions output
+inline void TG4VRegionsManager::SetFileName(const G4String& fileName)
+{ fFileName = fileName; }
+
+inline void TG4VRegionsManager::SetCheck(G4bool isCheck)
+{ fIsCheck = isCheck; }
+
+inline void TG4VRegionsManager::SetPrint(G4bool isPrint)
+{ fIsPrint = isPrint; }
+
+inline void TG4VRegionsManager::SetSave(G4bool isSave)
+{ fIsSave = isSave; }
+
+/// Return the file name for regions output
+inline G4String TG4VRegionsManager::GetFileName() const
+{ return fFileName; }
+
+/// Return the option to perform consistency check
+inline G4bool TG4VRegionsManager::IsCheck() const { return fIsCheck; }
+
+/// Return the option to print all regions
+inline G4bool TG4VRegionsManager::IsPrint() const { return fIsPrint; }
+
+/// Return option to save all regions in a file
+inline G4bool TG4VRegionsManager::IsSave() const { return fIsSave; }
+
+#endif // TG4_V_REGIONS_MANAGER_H

--- a/source/run/src/TG4RegionsManager2.cxx
+++ b/source/run/src/TG4RegionsManager2.cxx
@@ -1,0 +1,176 @@
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2007 - 2023 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TG4RegionsManager2.cxx
+/// \brief Implementation of the TG4RegionsManager2 class
+///
+/// \author I. Hrivnacova; IJCLab Orsay
+
+#include "TG4RegionsManager2.h"
+#include "TG4GeometryServices.h"
+#include "TG4Globals.h"
+#include "TG4Limits.h"
+#include "TG4Medium.h"
+#include "TG4PhysicsManager.h"
+
+#include <G4LogicalVolumeStore.hh>
+#include <G4Material.hh>
+#include <G4ProductionCuts.hh>
+#include <G4ProductionCutsTable.hh>
+#include <G4Region.hh>
+#include <G4RegionStore.hh>
+#include <G4SystemOfUnits.hh>
+
+//_____________________________________________________________________________
+TG4RegionsManager2::TG4RegionsManager2()
+ : fMessenger(this)
+{}
+
+//
+// public methods
+//
+
+//_____________________________________________________________________________
+void TG4RegionsManager2::DefineRegions()
+{
+  /// Define regions according to tracking media
+
+  if (VerboseLevel() > 0) {
+    G4cout << "Define regions for VMC cuts per materials." << G4endl;
+  }
+
+  // Get medium map
+  auto mediumMap = TG4GeometryServices::Instance()->GetMediumMap();
+  // Get G4 region store
+  auto g4RegionStore = G4RegionStore::GetInstance();
+
+  // Get world volume & material
+  auto worldLV = TG4GeometryServices::Instance()->GetWorld()->GetLogicalVolume();
+  auto worldMaterial = worldLV->GetMaterial();
+
+  // Get default range cut values from physics manager
+  auto defaultRangeCutEle =
+    TG4PhysicsManager::Instance()->GetCutForElectron();
+  auto defaultRangeCutGam = TG4PhysicsManager::Instance()->GetCutForGamma();
+  auto defaultRangeCutPositron =
+    TG4PhysicsManager::Instance()->GetCutForPositron();
+  auto defaultRangeCutProton =
+    TG4PhysicsManager::Instance()->GetCutForProton();
+
+  // Define region for each logical volume
+  G4int counter = 0;
+  auto lvStore = G4LogicalVolumeStore::GetInstance();
+
+  for (std::size_t i = 0; i < lvStore->size(); ++i) {
+
+    auto lv = (*lvStore)[i];
+    auto materialName = lv->GetMaterial()->GetName();
+    // print debug message
+    if (VerboseLevel() > 1) {
+      G4cout << "-- Volume = " << i << "  " << lv->GetName()
+             << " material = " << materialName << G4endl;
+    }
+
+    // skip world
+    if (lv == worldLV) {
+      if (VerboseLevel() > 1) {
+        G4cout << "   " << "skipping worldVolume" << G4endl;
+      }
+      continue;
+    }
+
+    // skip volume if it has already a region assigned
+    if (lv->GetRegion() != nullptr &&
+        lv->GetRegion()->GetName() == materialName) {
+        if (VerboseLevel() > 1) {
+           G4cout << "   "
+                  << "has already region set, skipping" << G4endl;
+        }
+        continue;
+    }
+
+    // Get region fior this material, if it already exists,
+    // and add the logical volume
+    auto regionName = materialName;
+    auto region = g4RegionStore->GetRegion(regionName, false);
+    if (region != nullptr) {
+      if (lv->GetRegion() != region) {
+        // Add volume to the region per material if its region is different
+        // (by default the volume has the DefaultRegionForTheWorld)
+        if (VerboseLevel() > 1) {
+          G4cout << "   "
+                 << "adding volume in region = " << regionName << G4endl;
+        }
+        region->AddRootLogicalVolume(lv);
+      }
+      continue;
+    }
+
+    // After this line, the region does not exist
+    if (VerboseLevel() > 1) {
+      G4cout << "   "
+             << "creating new region = " << regionName << G4endl;
+    }
+    region = new G4Region(regionName);
+    region->AddRootLogicalVolume(lv);
+    ++counter;
+  }
+
+  if (fIsCheck) {
+    CheckRegionsInGeometry();
+  }
+
+  if (VerboseLevel() > 0) {
+    G4cout << "Number of added regions: " << counter << G4endl;
+  }
+}
+
+//_____________________________________________________________________________
+void TG4RegionsManager2::UpdateProductionCutsTable()
+{
+  /// Update production cuts table according to stored region information
+
+  if (VerboseLevel() > 1) {
+    G4cout << "Update production cuts table" << G4endl;
+  }
+
+  auto mediumMap = TG4GeometryServices::Instance()->GetMediumMap();
+  auto g4ProductionCutsTable = G4ProductionCutsTable::GetProductionCutsTable();
+
+  // Global energy cuts
+  auto cutEleGlobal = GetGlobalEnergyCut(kCUTELE);
+  auto cutGamGlobal = GetGlobalEnergyCut(kCUTGAM);
+
+  // cut vectors for gamma, e-, e+, proton
+  std::vector<G4double> gamCuts; 
+  std::vector<G4double> eleCuts; 
+
+  // G4cout << "g4RegionStore size: " << G4RegionStore::GetInstance()->size() << G4endl;
+  // G4cout << "g4ProductionCutsTable size: " << g4ProductionCutsTable->GetTableSize() << G4endl;
+
+  // update table (create materials cut couples)
+  g4ProductionCutsTable->CreateCoupleTables(); 
+  // G4cout << "g4ProductionCutsTable size after update: " << g4ProductionCutsTable->GetTableSize() << G4endl;
+
+  for (std::size_t i = 0; i < g4ProductionCutsTable->GetTableSize(); ++i) {
+    auto couple = g4ProductionCutsTable->GetMaterialCutsCouple(i);
+    auto material = couple->GetMaterial();
+    auto medium = mediumMap->GetMedium(material);
+
+    auto limits = (TG4Limits*)medium->GetLimits();
+    auto cutEle = GetEnergyCut(limits, kCUTELE, cutEleGlobal);
+    auto cutGam = GetEnergyCut(limits, kCUTGAM, cutGamGlobal);
+
+    gamCuts.push_back(cutGam);
+    eleCuts.push_back(cutEle);
+  }
+
+  g4ProductionCutsTable->SetEnergyCutVector(gamCuts, 0);
+  g4ProductionCutsTable->SetEnergyCutVector(eleCuts, 1);
+}

--- a/source/run/src/TG4RegionsMessenger.cxx
+++ b/source/run/src/TG4RegionsMessenger.cxx
@@ -13,7 +13,9 @@
 /// \author I. Hrivnacova; IPN, Orsay
 
 #include "TG4RegionsMessenger.h"
+#include "TG4Globals.h"
 #include "TG4RegionsManager.h"
+#include "TG4RegionsManager2.h"
 
 #include <G4UIcmdWithABool.hh>
 #include <G4UIcmdWithADouble.hh>
@@ -22,94 +24,21 @@
 #include <G4UIdirectory.hh>
 
 //_____________________________________________________________________________
-TG4RegionsMessenger::TG4RegionsMessenger(TG4RegionsManager* runManager)
-  : G4UImessenger(),
-    fRegionsManager(runManager),
-    fDirectory(0),
-    fIsFromG4Table(false)
+TG4RegionsMessenger::TG4RegionsMessenger(TG4RegionsManager* regionsManager)
+  : fRegionsManager(regionsManager)
 {
   /// Standard constructor
 
-  fDirectory = new G4UIdirectory("/mcRegions/");
-  fDirectory->SetGuidance("TGeant4 regions commands.");
+  CreateCommands();
+}
 
-  fDumpRegionCmd = new G4UIcmdWithAString("/mcRegions/dumpRegion", this);
-  fDumpRegionCmd->SetGuidance("Dump characteristics of region ");
-  fDumpRegionCmd->SetParameterName("LVname", false);
-  fDumpRegionCmd->SetDefaultValue(" ");
-  fDumpRegionCmd->AvailableForStates(G4State_Idle, G4State_EventProc);
+//_____________________________________________________________________________
+TG4RegionsMessenger::TG4RegionsMessenger(TG4RegionsManager2* regionsManager)
+  : fRegionsManager2(regionsManager)
+{
+  /// Standard constructor
 
-  fSetRangePrecisionCmd =
-    new G4UIcmdWithAnInteger("/mcRegions/setRangePrecision", this);
-  fSetRangePrecisionCmd->SetGuidance(
-    "Set the precision for calculating ranges");
-  fSetRangePrecisionCmd->SetParameterName("RangePrecision", false);
-  fSetRangePrecisionCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetEnergyToleranceCmd =
-    new G4UIcmdWithADouble("/mcRegions/setEnergyTolerance", this);
-  fSetEnergyToleranceCmd->SetGuidance(
-    "Set the tolerance (relative) for comparing energy cut values");
-  fSetEnergyToleranceCmd->SetParameterName("EnergyTolerance", false);
-  fSetEnergyToleranceCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fApplyForGammaCmd = new G4UIcmdWithABool("/mcRegions/applyForGamma", this);
-  fApplyForGammaCmd->SetGuidance("Switch on|off applying range cuts for gamma");
-  fApplyForGammaCmd->SetParameterName("ApplyForGamma", false);
-  fApplyForGammaCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fApplyForElectronCmd =
-    new G4UIcmdWithABool("/mcRegions/applyForElectron", this);
-  fApplyForElectronCmd->SetGuidance("Switch on|off applying range cuts for e-");
-  fApplyForElectronCmd->SetParameterName("ApplyForElectron", false);
-  fApplyForElectronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fApplyForPositronCmd =
-    new G4UIcmdWithABool("/mcRegions/applyForPositron", this);
-  fApplyForPositronCmd->SetGuidance("Switch on|off applying range cuts for e+");
-  fApplyForPositronCmd->SetParameterName("ApplyForPositron", false);
-  fApplyForPositronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fApplyForProtonCmd = new G4UIcmdWithABool("/mcRegions/applyForProton", this);
-  fApplyForProtonCmd->SetGuidance(
-    "Switch on|off applying range cuts for protons");
-  fApplyForProtonCmd->SetParameterName("ApplyForProton", false);
-  fApplyForProtonCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetCheckCmd = new G4UIcmdWithABool("/mcRegions/check", this);
-  fSetCheckCmd->SetGuidance(
-    "Switch on|off check if region properties are consistent");
-  fSetCheckCmd->SetGuidance("with energy cuts defined in limits");
-  fSetCheckCmd->SetParameterName("IsCheck", false);
-  fSetCheckCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetPrintCmd = new G4UIcmdWithABool("/mcRegions/print", this);
-  fSetPrintCmd->SetGuidance("Switch on|off printing of all regions properties");
-  fSetPrintCmd->SetParameterName("IsPrint", false);
-  fSetPrintCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetSaveCmd = new G4UIcmdWithABool("/mcRegions/save", this);
-  fSetSaveCmd->SetGuidance("Switch on|off saving of all regions properties in a file");
-  fSetSaveCmd->SetParameterName("IsSave", false);
-  fSetSaveCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetLoadCmd = new G4UIcmdWithABool("/mcRegions/load", this);
-  fSetLoadCmd->SetGuidance("Switch on|off loading of all regions cuts & ranges from a file");
-  fSetLoadCmd->SetParameterName("IsLoad", false);
-  fSetLoadCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetFromG4TableCmd = new G4UIcmdWithABool("/mcRegions/fromG4Table", this);
-  fSetFromG4TableCmd->SetGuidance("Switch on|off printing or saving regions properties\n"
-    "from production cuts table.\n"
-    "Must be called before \"print\" or \"save\" command.");
-  fSetFromG4TableCmd->SetParameterName("IsFromG4Table", false);
-  fSetFromG4TableCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
-  fSetFileNameCmd = new G4UIcmdWithAString("/mcRegions/setFileName", this);
-  fSetFileNameCmd->SetGuidance("Set file name for the regions output");
-  fSetFileNameCmd->SetParameterName("FileName", false);
-  fSetFileNameCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-
+  CreateCommands();
 }
 
 //_____________________________________________________________________________
@@ -118,6 +47,10 @@ TG4RegionsMessenger::~TG4RegionsMessenger()
   /// Destructor
 
   delete fDirectory;
+  delete fSetCheckCmd;
+  delete fSetPrintCmd;
+  delete fSetSaveCmd;
+  delete fSetFileNameCmd;
   delete fDumpRegionCmd;
   delete fSetRangePrecisionCmd;
   delete fSetEnergyToleranceCmd;
@@ -125,12 +58,101 @@ TG4RegionsMessenger::~TG4RegionsMessenger()
   delete fApplyForElectronCmd;
   delete fApplyForPositronCmd;
   delete fApplyForProtonCmd;
-  delete fSetCheckCmd;
-  delete fSetPrintCmd;
-  delete fSetSaveCmd;
   delete fSetLoadCmd;
   delete fSetFromG4TableCmd;
-  delete fSetFileNameCmd;
+}
+
+//
+// private methods
+//
+
+//_____________________________________________________________________________
+void TG4RegionsMessenger::CreateCommands()
+{
+  /// Create commands
+
+  fDirectory = new G4UIdirectory("/mcRegions/");
+  fDirectory->SetGuidance("TGeant4 regions commands.");
+
+  fSetCheckCmd = new G4UIcmdWithABool("/mcRegions/check", this);
+  fSetCheckCmd->SetGuidance(
+    "Switch on|off check if region properties are consistent");
+  fSetCheckCmd->SetGuidance("with energy cuts defined in limits");
+  fSetCheckCmd->SetParameterName("IsCheck", false);
+  fSetCheckCmd->AvailableForStates(G4State_PreInit, G4State_Init, G4State_Idle, G4State_EventProc);
+
+  fSetPrintCmd = new G4UIcmdWithABool("/mcRegions/print", this);
+  fSetPrintCmd->SetGuidance("Switch on|off printing of all regions properties");
+  fSetPrintCmd->SetParameterName("IsPrint", false);
+  fSetPrintCmd->AvailableForStates(G4State_PreInit, G4State_Init, G4State_Idle, G4State_EventProc);
+
+  fSetSaveCmd = new G4UIcmdWithABool("/mcRegions/save", this);
+  fSetSaveCmd->SetGuidance("Switch on|off saving of all regions properties in a file");
+  fSetSaveCmd->SetParameterName("IsSave", false);
+  fSetSaveCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fSetFileNameCmd = new G4UIcmdWithAString("/mcRegions/setFileName", this);
+  fSetFileNameCmd->SetGuidance("Set file name for the regions output");
+  fSetFileNameCmd->SetParameterName("FileName", false);
+  fSetFileNameCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fSetRangePrecisionCmd =
+    new G4UIcmdWithAnInteger("/mcRegions/setRangePrecision", this);
+  fSetRangePrecisionCmd->SetGuidance(
+    "Set the precision for calculating ranges");
+  fSetRangePrecisionCmd->SetParameterName("RangePrecision", false);
+  fSetRangePrecisionCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  if (fRegionsManager != nullptr) {
+    // commands working only with old regions manager
+    fDumpRegionCmd = new G4UIcmdWithAString("/mcRegions/dumpRegion", this);
+    fDumpRegionCmd->SetGuidance("Dump characteristics of region ");
+    fDumpRegionCmd->SetParameterName("LVname", false);
+    fDumpRegionCmd->SetDefaultValue(" ");
+    fDumpRegionCmd->AvailableForStates(G4State_Idle, G4State_EventProc);
+
+    fSetEnergyToleranceCmd =
+      new G4UIcmdWithADouble("/mcRegions/setEnergyTolerance", this);
+    fSetEnergyToleranceCmd->SetGuidance(
+      "Set the tolerance (relative) for comparing energy cut values");
+    fSetEnergyToleranceCmd->SetParameterName("EnergyTolerance", false);
+    fSetEnergyToleranceCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  
+    fApplyForGammaCmd = new G4UIcmdWithABool("/mcRegions/applyForGamma", this);
+    fApplyForGammaCmd->SetGuidance("Switch on|off applying range cuts for gamma");
+    fApplyForGammaCmd->SetParameterName("ApplyForGamma", false);
+    fApplyForGammaCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  
+    fApplyForElectronCmd =
+      new G4UIcmdWithABool("/mcRegions/applyForElectron", this);
+    fApplyForElectronCmd->SetGuidance("Switch on|off applying range cuts for e-");
+    fApplyForElectronCmd->SetParameterName("ApplyForElectron", false);
+    fApplyForElectronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  
+    fApplyForPositronCmd =
+      new G4UIcmdWithABool("/mcRegions/applyForPositron", this);
+    fApplyForPositronCmd->SetGuidance("Switch on|off applying range cuts for e+");
+    fApplyForPositronCmd->SetParameterName("ApplyForPositron", false);
+    fApplyForPositronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  
+    fApplyForProtonCmd = new G4UIcmdWithABool("/mcRegions/applyForProton", this);
+    fApplyForProtonCmd->SetGuidance(
+      "Switch on|off applying range cuts for protons");
+    fApplyForProtonCmd->SetParameterName("ApplyForProton", false);
+    fApplyForProtonCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  
+    fSetLoadCmd = new G4UIcmdWithABool("/mcRegions/load", this);
+    fSetLoadCmd->SetGuidance("Switch on|off loading of all regions cuts & ranges from a file");
+    fSetLoadCmd->SetParameterName("IsLoad", false);
+    fSetLoadCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  
+    fSetFromG4TableCmd = new G4UIcmdWithABool("/mcRegions/fromG4Table", this);
+    fSetFromG4TableCmd->SetGuidance("Switch on|off printing or saving regions properties\n"
+      "from production cuts table.\n"
+      "Must be called before \"print\" or \"save\" command.");
+    fSetFromG4TableCmd->SetParameterName("IsFromG4Table", false);
+    fSetFromG4TableCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+  }
 }
 
 //
@@ -142,49 +164,93 @@ void TG4RegionsMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
 {
   /// Apply command to the associated object.
 
-  if (command == fDumpRegionCmd) {
-    fRegionsManager->DumpRegion(newValue);
+  if (fRegionsManager2 != nullptr) {
+    if (command == fSetCheckCmd) {
+      fRegionsManager2->SetCheck(fSetCheckCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetPrintCmd) {
+      fRegionsManager2->SetPrint(fSetPrintCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetSaveCmd) {
+      fRegionsManager2->SetSave(fSetSaveCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetFileNameCmd) {
+      fRegionsManager2->SetFileName(newValue);
+      return;
+    }
+    if (command == fSetRangePrecisionCmd) {
+      TG4Globals::Warning("TG4RegionsMessenger", "SetNewValue",
+        "/mcRegions/setRangePrecision has no effect"
+        " when production cuts are set by energy.");
+      return;
+    }
   }
-  else if (command == fSetRangePrecisionCmd) {
-    fRegionsManager->SetRangePrecision(
-      fSetRangePrecisionCmd->GetNewIntValue(newValue));
-  }
-  else if (command == fSetEnergyToleranceCmd) {
-    fRegionsManager->SetEnergyTolerance(
-      fSetEnergyToleranceCmd->GetNewDoubleValue(newValue));
-  }
-  else if (command == fApplyForGammaCmd) {
-    fRegionsManager->SetApplyForGamma(
-      fApplyForGammaCmd->GetNewBoolValue(newValue));
-  }
-  else if (command == fApplyForElectronCmd) {
-    fRegionsManager->SetApplyForGamma(
-      fApplyForElectronCmd->GetNewBoolValue(newValue));
-  }
-  else if (command == fApplyForPositronCmd) {
-    fRegionsManager->SetApplyForPositron(
-      fApplyForPositronCmd->GetNewBoolValue(newValue));
-  }
-  else if (command == fApplyForProtonCmd) {
-    fRegionsManager->SetApplyForProton(
-      fApplyForProtonCmd->GetNewBoolValue(newValue));
-  }
-  else if (command == fSetCheckCmd) {
-    fRegionsManager->SetCheck(fSetCheckCmd->GetNewBoolValue(newValue));
-  }
-  else if (command == fSetPrintCmd) {
-    fRegionsManager->SetPrint(fSetPrintCmd->GetNewBoolValue(newValue), fIsFromG4Table);
-  }
-  else if (command == fSetSaveCmd) {
-    fRegionsManager->SetSave(fSetSaveCmd->GetNewBoolValue(newValue), fIsFromG4Table);
-  }
-  else if (command == fSetLoadCmd) {
-    fRegionsManager->SetLoad(fSetLoadCmd->GetNewBoolValue(newValue));
-  }
-  else if (command == fSetFromG4TableCmd) {
-    fIsFromG4Table = fSetFromG4TableCmd->GetNewBoolValue(newValue);
-  }
-  else if (command == fSetFileNameCmd) {
-    fRegionsManager->SetFileName(newValue);
+
+  if (fRegionsManager != nullptr) {
+    if (command == fSetCheckCmd) {
+      fRegionsManager-> SetCheck(fSetCheckCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetPrintCmd) {
+      fRegionsManager->SetPrint(fSetPrintCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetSaveCmd) {
+      fRegionsManager->SetSave(fSetSaveCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetFileNameCmd) {
+      fRegionsManager->SetFileName(newValue);
+      return;
+    }
+    if (command == fDumpRegionCmd) {
+      fRegionsManager-> DumpRegion(newValue);
+      return;
+    }
+    if (command == fSetRangePrecisionCmd) {
+      fRegionsManager->SetRangePrecision(
+        fSetRangePrecisionCmd->GetNewIntValue(newValue));
+      return;
+    }
+    if (command == fSetEnergyToleranceCmd) {
+      fRegionsManager->SetEnergyTolerance(
+        fSetEnergyToleranceCmd->GetNewDoubleValue(newValue));
+      return;
+    }
+    if (command == fApplyForGammaCmd) {
+      fRegionsManager->SetApplyForGamma(
+        fApplyForGammaCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fApplyForElectronCmd) {
+      fRegionsManager->SetApplyForGamma(
+        fApplyForElectronCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fApplyForPositronCmd) {
+      fRegionsManager->SetApplyForPositron(
+        fApplyForPositronCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fApplyForProtonCmd) {
+      fRegionsManager->SetApplyForProton(
+        fApplyForProtonCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetLoadCmd) {
+      fRegionsManager->SetLoad(fSetLoadCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetFromG4TableCmd) {
+      fRegionsManager->SetFromG4Table(
+        fSetFromG4TableCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fSetFileNameCmd) {
+      fRegionsManager->SetFileName(newValue);
+    }
   }
 }

--- a/source/run/src/TG4RunAction.cxx
+++ b/source/run/src/TG4RunAction.cxx
@@ -17,7 +17,7 @@
 // times system function this include must be the first
 
 #include "TG4Globals.h"
-#include "TG4RegionsManager.h"
+#include "TG4VRegionsManager.h"
 #include "TG4RunAction.h"
 #include "TGeant4.h"
 
@@ -167,15 +167,16 @@ void TG4RunAction::BeginOfRunAction(const G4Run* run)
     G4cout << "### Run " << run->GetRunID() << " start." << G4endl;
   }
 
-  if (TG4RegionsManager::Instance()) {
-    if (TG4RegionsManager::Instance()->IsCheck()) {
-      TG4RegionsManager::Instance()->CheckRegions();
+  auto regionsManager = TG4VRegionsManager::Instance();
+  if (regionsManager != nullptr) {
+    if (regionsManager->IsCheck()) {
+      regionsManager->CheckRegions();
     }
-    if (TG4RegionsManager::Instance()->IsPrint()) {
-      TG4RegionsManager::Instance()->PrintRegions(G4cout);
+    if (regionsManager->IsPrint()) {
+      regionsManager->PrintRegions(G4cout);
     }
-    if (TG4RegionsManager::Instance()->IsSave()) {
-      TG4RegionsManager::Instance()->SaveRegions();
+    if (regionsManager->IsSave()) {
+      regionsManager->SaveRegions();
     }
   }
 

--- a/source/run/src/TG4RunConfiguration.cxx
+++ b/source/run/src/TG4RunConfiguration.cxx
@@ -48,6 +48,7 @@ TG4RunConfiguration::TG4RunConfiguration(const TString& userGeometry,
     fMTApplication(mtApplication),
     fSpecialControls(false),
     fSpecialCuts(false),
+    fSpecialCutsOld(false),
     fAGDDMessenger(0),
     fGDMLMessenger(0),
     fParameters()
@@ -320,6 +321,19 @@ void TG4RunConfiguration::SetParameter(const TString& name, Double_t value)
 }
 
 //_____________________________________________________________________________
+void TG4RunConfiguration::SetSpecialCutsOld()
+{
+  /// Activate usage of old regions manager
+  /// that sets production thresholds by ranges
+
+  G4cout
+    << "### Special cuts old activated: production cuts will be set by ranges."
+    << G4endl;
+
+  fSpecialCutsOld = true;
+}
+
+//_____________________________________________________________________________
 TString TG4RunConfiguration::GetUserGeometry() const
 {
   /// Return the way user geometry is built
@@ -350,9 +364,17 @@ Bool_t TG4RunConfiguration::IsSpecialControls() const
 //_____________________________________________________________________________
 Bool_t TG4RunConfiguration::IsSpecialCuts() const
 {
-  /// Return true if special controls are activated
+  /// Return true if special cuts are activated
 
   return fSpecialCuts;
+}
+
+//_____________________________________________________________________________
+Bool_t TG4RunConfiguration::IsSpecialCutsOld() const
+{
+  /// Return true if special cuts old are activated
+
+  return fSpecialCutsOld;
 }
 
 //_____________________________________________________________________________

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -23,6 +23,7 @@
 #include "TG4PhysicsManager.h"
 #include "TG4PostDetConstruction.h"
 #include "TG4RegionsManager.h"
+#include "TG4RegionsManager2.h"
 #include "TG4RunConfiguration.h"
 #include "TG4SDConstruction.h"
 #include "TG4SDManager.h"
@@ -293,7 +294,14 @@ void TG4RunManager::ConfigureRunManager()
 
   // Regions manager
   //
-  fRegionsManager = new TG4RegionsManager();
+  if (fRunConfiguration->IsSpecialCuts()) {
+    if (fRunConfiguration->IsSpecialCutsOld()) {
+      fRegionsManager = new TG4RegionsManager();
+    }
+    else {
+      fRegionsManager = new TG4RegionsManager2();
+    }
+  }
 
   if (VerboseLevel() > 1)
     G4cout << "TG4RunManager::ConfigureRunManager done " << this << G4endl;
@@ -450,7 +458,10 @@ void TG4RunManager::LateInitialize()
     //  ->SetIsPairCut((*TG4G3PhysicsManager::Instance()->GetIsCutVector())[kEplus]);
 
     // convert tracking cuts in range cuts per regions
-    if (fRunConfiguration->IsSpecialCuts()) fRegionsManager->DefineRegions();
+    if (fRunConfiguration->IsSpecialCuts()) {
+      fRegionsManager->DefineRegions();
+      fRegionsManager->UpdateProductionCutsTable();
+    }
   }
 
   // activate/inactivate physics processes

--- a/source/run/src/TG4VRegionsManager.cxx
+++ b/source/run/src/TG4VRegionsManager.cxx
@@ -1,0 +1,354 @@
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2007 - 2023 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TG4VRegionsManager.cxx
+/// \brief Implementation of the TG4VRegionsManager class
+///
+/// \author I. Hrivnacova; IJCLab Orsay
+
+#include "TG4VRegionsManager.h"
+#include "TG4G3CutVector.h"
+#include "TG4G3PhysicsManager.h"
+#include "TG4G3Units.h"
+#include "TG4GeometryServices.h"
+#include "TG4Globals.h"
+#include "TG4Limits.h"
+#include "TG4Medium.h"
+#include "TG4RegionsMessenger.h"
+
+#include <G4LogicalVolumeStore.hh>
+#include <G4ProductionCuts.hh>
+#include <G4Region.hh>
+#include <G4RegionStore.hh>
+#include <G4RunManager.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4UnitsTable.hh>
+#include <G4VUserPhysicsList.hh>
+#include <G4Version.hh>
+
+#include <map>
+#include <set>
+#include <fstream>
+
+TG4VRegionsManager* TG4VRegionsManager::fgInstance = nullptr;
+
+const G4String TG4VRegionsManager::fgkDefaultRegionName =
+  "RegionWithDefaultCuts";
+const G4String TG4VRegionsManager::fgkDefaultFileName = "regions.dat";
+
+//_____________________________________________________________________________
+TG4VRegionsManager::TG4VRegionsManager()
+  : TG4Verbose("regionsManager")
+{
+  /// Default constructor
+
+  fgInstance = this;
+}
+
+//_____________________________________________________________________________
+TG4VRegionsManager::~TG4VRegionsManager()
+{
+  /// Destructor
+
+  fgInstance = nullptr;
+}
+
+//
+// protected methods
+//
+
+//_____________________________________________________________________________
+G4double TG4VRegionsManager::GetGlobalEnergyCut(TG4G3Cut cutType) const
+{
+  /// Return global cut in energy of given cutType.
+  /// Return DBL_MAX if cut value is not defined
+
+  TG4boolVector* isCutVector =
+    TG4G3PhysicsManager::Instance()->GetIsCutVector();
+  TG4G3CutVector* cutVector = TG4G3PhysicsManager::Instance()->GetCutVector();
+
+  G4double cutValue = DBL_MAX;
+  if ((*isCutVector)[cutType] && (*cutVector)[cutType] > DBL_MIN) {
+    cutValue = (*cutVector)[cutType];
+  }
+
+  return cutValue;
+}
+
+//_____________________________________________________________________________
+G4double TG4VRegionsManager::GetEnergyCut(
+  TG4Limits* limits, TG4G3Cut cutType, G4double globalCutValue) const
+{
+  /// Return cut in energy defined in limits of given cutType.
+  /// Return DBL_MAX if cut value is not defined.
+
+  G4double cut = DBL_MAX;
+  if (limits->GetCutVector() && (*limits->GetCutVector())[cutType] > DBL_MIN) {
+    cut = (*limits->GetCutVector())[cutType];
+  }
+  else {
+    cut = globalCutValue;
+  }
+
+  return cut;
+}
+
+//_____________________________________________________________________________
+G4bool TG4VRegionsManager::IsCoupleUsedInTheRegion(
+  const G4MaterialCutsCouple* couple, const G4Region* region) const
+{
+  /// Reimplemented G4ProductionCutsTable::IsCoupleUsedInTheRegion
+  /// which is declared private
+
+  G4ProductionCuts* productionCuts = region->GetProductionCuts();
+  std::vector<G4Material*>::const_iterator itm = region->GetMaterialIterator();
+  size_t nofMaterials = region->GetNumberOfMaterials();
+  for (size_t i = 0; i < nofMaterials; i++, itm++) {
+    if (couple->GetMaterial() == (*itm) &&
+        couple->GetProductionCuts() == productionCuts) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+///_____________________________________________________________________________
+void TG4VRegionsManager::CheckRegionsInGeometry() const
+{
+  /// Loop over all logical volumes and check if the region to which
+  /// the volume belongs correspond to its material
+
+  if (VerboseLevel() > 0) {
+    G4cout << ".. Checking regions materials " << G4endl;
+  }
+
+  Bool_t good = true;
+  G4LogicalVolumeStore* lvStore = G4LogicalVolumeStore::GetInstance();
+  for (G4int i = 0; i < G4int(lvStore->size()); i++) {
+
+    G4LogicalVolume* lv = (*lvStore)[i];
+
+    // skip world volume
+    if (lv == TG4GeometryServices::Instance()->GetWorld()->GetLogicalVolume())
+      continue;
+
+    // skip volume without medium
+    TG4Medium* medium =
+      TG4GeometryServices::Instance()->GetMediumMap()->GetMedium(lv, false);
+    if (!medium) continue;
+
+    if (lv->GetRegion()->GetName() != lv->GetMaterial()->GetName() &&
+        lv->GetRegion()->GetName() != fgkDefaultRegionName) {
+
+      G4cout << "The region name " << lv->GetRegion()->GetName()
+             << " for LV = " << lv->GetName()
+             << " does not match its material name "
+             << lv->GetMaterial()->GetName() << G4endl;
+
+      good = false;
+    }
+  }
+  if (good) {
+    G4cout << ".. Regions are consistent with materials." << G4endl;
+  }
+  else {
+    G4cout << ".. Found inconsistencies between regions and materials."
+           << G4endl;
+  }
+}
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::PrintLegend(std::ostream& output) const
+{
+  /// Print the range data legend
+
+  //clang-format off
+  output << std::setw(30) << std::left << "# material name"
+         << "  rangeGam[mm]"
+         << "  rangeEle[mm]"
+         << "   cutGam[GeV]"
+         << "   cutEle[GeV]"
+         << " vmcCutGam[GeV]"
+         << " vmcCutEle[GeV]" << G4endl;
+  //clang-format on
+}
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::PrintRegionData(std::ostream& output,
+  const G4String& matName, const TG4RegionData& values) const
+{
+  /// Print one region data.
+  /// The regions names are printed within '' and separated from the following date
+  /// with ';' to facilitate reading data back. The procedure then works only with
+  /// material names that do not contain these two special characters.
+
+  auto name = "\'" + matName + "\';";
+
+  // Print all data
+  //clang-format off
+  output << std::setw(30) << std::left << name << "  "
+         << std::scientific << values[fgkRangeGamIdx] << "  "
+         << std::scientific << values[fgkRangeEleIdx] << "  "
+         << std::scientific << values[fgkCutGamIdx] * TG4G3Units::InverseEnergy() << "  "
+         << std::scientific << values[fgkCutEleIdx] * TG4G3Units::InverseEnergy() << "  "
+         << std::scientific << values[fgkVmcCutGamIdx] * TG4G3Units::InverseEnergy() << "  "
+         << std::scientific << values[fgkVmcCutEleIdx] * TG4G3Units::InverseEnergy() << G4endl;
+  //clang-format on
+}
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::PrintFromG4Table(std::ostream& output) const
+{
+  /// Loop over the production cuts table and print the production ranges
+  /// and cuts from the table and the VMC cuts from the TG4Limits
+  /// associated with the production cuts material.
+
+  G4ProductionCutsTable* productionCutsTable =
+    G4ProductionCutsTable::GetProductionCutsTable();
+
+  if (productionCutsTable->GetTableSize() == 0) {
+    G4cout << "No production cuts defined." << G4endl;
+    return;
+  }
+
+  PrintLegend(output);
+
+  for (G4int i = 0; i < G4int(productionCutsTable->GetTableSize()); i++) {
+    const G4MaterialCutsCouple* couple =
+      productionCutsTable->GetMaterialCutsCouple(i);
+
+    const G4Material* material = couple->GetMaterial();
+    G4ProductionCuts* cuts = couple->GetProductionCuts();
+
+    G4double rangeGam = cuts->GetProductionCut(0);
+    G4double rangeEle = cuts->GetProductionCut(1);
+    // if ( couple->IsRecalcNeeded() ) {
+    //  TG4Globals::Warning("TG4VRegionsManager", "PrintProductionCuts",
+    //     "Recalculation is needed - the energy cuts may be wrong");
+    // }
+
+    const std::vector<G4double>* energyCutsGam =
+      productionCutsTable->GetEnergyCutsVector(0);
+    const std::vector<G4double>* energyCutsEle =
+      productionCutsTable->GetEnergyCutsVector(1);
+
+    G4double cutGam = (*energyCutsGam)[couple->GetIndex()];
+    G4double cutEle = (*energyCutsEle)[couple->GetIndex()];
+
+    // Get limits via material
+    TG4Limits* limits =
+      TG4GeometryServices::Instance()->FindLimits(material, true);
+
+    G4double cutGamLimits = DBL_MAX;
+    G4double cutEleLimits = DBL_MAX;
+    if (!limits) {
+      TG4Globals::Warning("TG4VRegionsManager", "CheckRegions",
+        "Limits for material " + TString(material->GetName()) + " not found. " +
+          TG4Globals::Endl());
+    }
+    else {
+      cutGamLimits = GetEnergyCut(limits, kCUTGAM, DBL_MAX);
+      cutEleLimits = GetEnergyCut(limits, kCUTELE, DBL_MAX);
+    }
+
+    G4String matName = material->GetName();
+    TG4RegionData values =
+      {rangeGam, rangeEle, cutGam, cutEle, cutGamLimits, cutEleLimits};
+
+    PrintRegionData(output, matName, values);
+  }
+}
+
+//
+// public methods
+//
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::PrintRegions(std::ostream& output) const
+{
+  /// Print regions from the production cuts table.
+
+  PrintFromG4Table(output);
+}
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::CheckRegions() const
+{
+  /// Check if the region to which the volume belongs correspond to its material
+
+  CheckRegionsInGeometry();
+}
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::SaveRegions()
+{
+  /// Dump all regions data in a file
+
+  // Open file
+  auto fileName = fFileName.empty() ? fgkDefaultFileName : fFileName;
+  std::ofstream fileOutput;
+  fileOutput.open(fileName, std::ios::out);
+  if (! fileOutput.is_open()) {
+    TG4Globals::Warning("TG4VRegionsManager", "SaveRegions",
+      "Saving regions in file " + TString(fileName.data()) + " has failed.");
+    return;
+  }
+
+  if (VerboseLevel() > 0) {
+    G4cout << "Saving regions from production cuts table in file: " << fileName << G4endl;
+  }
+
+  PrintRegions(fileOutput);
+  fileOutput.close();
+}
+
+//_____________________________________________________________________________
+void TG4VRegionsManager::DumpRegionStore() const
+{
+  /// Dump all region properties:
+  /// production cuts, volumes list and material list.
+
+  auto regionStore = G4RegionStore::GetInstance();
+
+  G4cout << "========= Region Store Dump ======================================"
+         << G4endl;
+
+  for (auto region : *regionStore ) {
+    G4cout << region->GetName() << ":" << G4endl;
+
+    auto cuts = region->GetProductionCuts();
+    if (cuts != nullptr) {
+      auto rangeGam = cuts->GetProductionCut(0);
+      auto rangeEle = cuts->GetProductionCut(1);
+      G4cout << "  ProductionCuts: rangeGam=" << rangeGam << "  rangeEle=" << rangeEle << G4endl;
+    }
+
+    size_t lvCounter = 0;
+    auto lvIt = region->GetRootLogicalVolumeIterator();
+    G4cout << "  RootVolumes: ";
+    while (lvCounter < region->GetNumberOfRootVolumes()) {
+      G4cout << " " << (*lvIt++)->GetName() << "; ";
+      ++lvCounter;
+    }
+    G4cout << G4endl;;
+
+    size_t matCounter = 0;
+    auto matIt = region->GetMaterialIterator();
+    G4cout << "  Materials: ";
+    while (matCounter < region->GetNumberOfMaterials()) {
+      G4cout << " " << (*matIt)->GetName() << "; ";;
+      ++matCounter;
+    }
+    G4cout << G4endl;;
+  }
+
+  G4cout << "========= End Region Store Dump =================================="
+         << G4endl;
+}


### PR DESCRIPTION
- Introduced TG4VRegionsManager base class with common implementation and new TG4RegionManager2 using new G4ProductionCutsTable::SetEnergyCutVector function
- Added an option 'IsSpecialCutsOld' in TG4RunConfiguration that allows to switch to old way of computation of production cuts

- In E03: updates in cuts setting:
  - SetCuts: Set 100 keV cut everywhere to make easier to test that the cuts are applied
   - In E03/g4[TGeo]Config4[seq].C - added a commented line that can be used to activate the old regions manager that sets production thresholds by ranges
   - In test_E03_5,6.C added default parameters

- Reduced TG4GeometryManager verbosity for level 2:
  - In ConstructZeroFields(): pront only volumes with field switch off