### PR TITLE
Removed pythia6 dependent libraries from g3libs.C

### DIFF
--- a/examples/macro/g3libs.C
+++ b/examples/macro/g3libs.C
@@ -36,11 +36,6 @@ void g3libs()
 {
 /// Macro function for loading Geant3 libraries
 
-  // Load libraries required by Geant3
-  gSystem->Load("libPythia6");
-  gSystem->Load("libEG");
-  gSystem->Load("libEGPythia6");
-
   // VMC library (optional)
   if ( g3libUtilities::isLibrary("libVMCLibrary") ) {
     cout << "Loading VMC library ..." << endl;


### PR DESCRIPTION
The dependencies on pythia6 were removed from geant3 library in geant3 4.3.

The pythia6 interface is deprecated in ROOT since version 6.30 (see https://root.cern/doc/v630/release-notes.html)
