### PR TITLE
Map the 'PFIS' control to "photonNuclear" process(es)

### DIFF
--- a/examples/E03/g4Config.C
+++ b/examples/E03/g4Config.C
@@ -37,5 +37,8 @@ void Config()
   // (verbose level, global range cut, ..)
   geant4->ProcessGeantMacro("g4config.in");
 
+  // Switch off photo nuclear process
+  // geant4->SetProcess("PFIS", 0);
+
   cout << "Processing Config() done." << endl;
 }

--- a/examples/E03/g4config.in
+++ b/examples/E03/g4config.in
@@ -25,6 +25,9 @@
 #/mcTracking/saveSecondariesInStep true
 #/mcPrimaryGenerator/skipUnknownParticles true
 
+# switch off use of Gamma General Process
+#/process/em/UseGeneralProcess false
+
 #/tracking/verbose 1
 
 /mcPhysics/rangeCuts 0.01 mm

--- a/examples/E03/g4tgeoConfig.C
+++ b/examples/E03/g4tgeoConfig.C
@@ -36,4 +36,9 @@ void Config()
   // Customise Geant4 setting
   // (verbose level, global range cut, ..)
   geant4->ProcessGeantMacro("g4config.in");
+
+  // Switch off photo nuclear process
+  // geant4->SetProcess("PFIS", 0);
+
+  cout << "Processing Config() done." << endl;
 }

--- a/source/physics_list/src/TG4ProcessMapPhysics.cxx
+++ b/source/physics_list/src/TG4ProcessMapPhysics.cxx
@@ -149,7 +149,7 @@ void TG4ProcessMapPhysics::FillMap()
   pMap->Add(fElectronNuclear, kPElectronNuclear, kHADR);           // TG4 value: 171
   pMap->Add(fPositronNuclear, kPPositronNuclear, kHADR);           // TG4 value: 172
   pMap->Add(fMuonNuclear, kPMuonNuclear, kMUNU);                   // TG4 value: 173
-  pMap->Add(fPhotoNuclear, kPPhotoNuclear, kHADR);                 // TG4 value: 174
+  pMap->Add(fPhotoNuclear, kPPhotoNuclear, kPFIS);                 // TG4 value: 174
 
   // G4DecayProcessType: 201 - 231
   pMap->Add(DECAY, kPDecay, kDCAY);                                // G4 value: 201


### PR DESCRIPTION
- Added special treatment of gamma processes if G4GeneralGammaProcess is in use: the 'PFIS' control can be still applied, for the other gamma related controls a warning is issued inviting users to switch G4GeneralGammaProcess off
- Added comments that demonstrate switching off the 'PFIS' control and Gamma General Process in E03 config files