### PR TITLE
Fix & improvements in new setting productions cuts per energy (#56)

### DIFF
--- a/source/physics/include/TG4PhysicsManager.h
+++ b/source/physics/include/TG4PhysicsManager.h
@@ -227,7 +227,7 @@ inline G4double TG4PhysicsManager::GetCutForPositron() const
 
 inline G4double TG4PhysicsManager::GetCutForProton() const
 {
-  /// Return range cut for positron
+  /// Return range cut for proton
   return fCutForProton;
 }
 

--- a/source/run/include/TG4RegionsManager.h
+++ b/source/run/include/TG4RegionsManager.h
@@ -92,20 +92,12 @@ class TG4RegionsManager : public TG4VRegionsManager
   // set methods
   void SetRangePrecision(G4int precision);
   void SetEnergyTolerance(G4double tolerance);
-  void SetApplyForGamma(G4bool applyForGamma);
-  void SetApplyForElectron(G4bool applyForElectron);
-  void SetApplyForPositron(G4bool applyForPositron);
-  void SetApplyForProton(G4bool applyForProton);
   void SetLoad(G4bool isLoad);
   void SetFromG4Table(G4bool isG4Table);
 
   // get methods
   G4int GetRangePrecision() const;
   G4double GetEnergyTolerance() const;
-  G4bool GetApplyForGamma() const;
-  G4bool GetApplyForElectron() const;
-  G4bool GetApplyForPositron() const;
-  G4bool GetApplyForProton() const;
   G4String GetFileName() const;
   G4bool IsG4Table() const;
   G4bool IsLoad() const;
@@ -157,14 +149,6 @@ class TG4RegionsManager : public TG4VRegionsManager
   G4int fRangePrecision = fgkDefaultRangePrecision;
   /// the tolerance (relative) for comparing energy cut values
   G4double fEnergyTolerance = fgkDefaultEnergyTolerance;
-  /// option to apply range cuts for gamma (default is true)
-  G4bool fApplyForGamma = true;
-  /// option to apply range cuts for e- (default is true)
-  G4bool fApplyForElectron = true;
-  /// option to apply range cuts for e+ (default is true)
-  G4bool fApplyForPositron = true;
-  /// option to apply range cuts for proton (default is true)
-  G4bool fApplyForProton = true;
   /// option to print or save regions from G4 production cuts table
   G4bool fIsG4Table = false;
   /// option to load regions ranges from a file
@@ -187,30 +171,6 @@ inline void TG4RegionsManager::SetEnergyTolerance(G4double tolerance)
   fEnergyTolerance = tolerance;
 }
 
-/// Set the option to apply range cuts for gamma (default is true)
-inline void TG4RegionsManager::SetApplyForGamma(G4bool applyForGamma)
-{
-  fApplyForGamma = applyForGamma;
-}
-
-/// Set the option to apply range cuts for e- (default is true)
-inline void TG4RegionsManager::SetApplyForElectron(G4bool applyForElectron)
-{
-  fApplyForElectron = applyForElectron;
-}
-
-/// Set the option to apply range cuts for e+ (default is true)
-inline void TG4RegionsManager::SetApplyForPositron(G4bool applyForPositron)
-{
-  fApplyForPositron = applyForPositron;
-}
-
-/// Set the option to apply range cuts for proton (default is true)
-inline void TG4RegionsManager::SetApplyForProton(G4bool applyForProton)
-{
-  fApplyForProton = applyForProton;
-}
-
 /// Set the option to print/save cuts from G4 table
 inline void TG4RegionsManager::SetFromG4Table(G4bool isG4Table)
 {
@@ -227,30 +187,6 @@ inline G4int TG4RegionsManager::GetRangePrecision() const
 inline G4double TG4RegionsManager::GetEnergyTolerance() const
 {
   return fEnergyTolerance;
-}
-
-/// Return the option to apply range cuts for gamma
-inline G4bool TG4RegionsManager::GetApplyForGamma() const
-{
-  return fApplyForGamma;
-}
-
-/// Return the option to apply range cuts for e+
-inline G4bool TG4RegionsManager::GetApplyForElectron() const
-{
-  return fApplyForElectron;
-}
-
-/// Return the option to apply range cuts for positron
-inline G4bool TG4RegionsManager::GetApplyForPositron() const
-{
-  return fApplyForPositron;
-}
-
-/// Return the option to apply range cuts for proton
-inline G4bool TG4RegionsManager::GetApplyForProton() const
-{
-  return fApplyForProton;
 }
 
 /// Return the option to print or save regions from production cuts table

--- a/source/run/include/TG4VRegionsManager.h
+++ b/source/run/include/TG4VRegionsManager.h
@@ -54,12 +54,20 @@ class TG4VRegionsManager : public TG4Verbose
 
   // set methods
   void SetFileName(const G4String& fileName);
+  void SetApplyForGamma(G4bool applyForGamma);
+  void SetApplyForElectron(G4bool applyForElectron);
+  void SetApplyForPositron(G4bool applyForPositron);
+  void SetApplyForProton(G4bool applyForProton);
   void SetCheck(G4bool isCheck);
   void SetPrint(G4bool isPrint);
   void SetSave(G4bool isSave);
 
   // get methods
   G4String GetFileName() const;
+  G4bool GetApplyForGamma() const;
+  G4bool GetApplyForElectron() const;
+  G4bool GetApplyForPositron() const;
+  G4bool GetApplyForProton() const;
   G4bool IsCheck() const;
   G4bool IsPrint() const;
   G4bool IsSave() const;
@@ -109,12 +117,20 @@ class TG4VRegionsManager : public TG4Verbose
 
   /// file name for regions output
   G4String fFileName;
+  /// option to apply cuts for gamma (default is true)
+  G4bool fApplyForGamma = true;
+  /// option to apply cuts for e- (default is true)
+  G4bool fApplyForElectron = true;
+  /// option to apply cuts for e+ (default is true)
+  G4bool fApplyForPositron = true;
+  /// option to apply cuts for proton (default is true)
+  G4bool fApplyForProton = true;
   /// option to perform consistency check (by default false)
   G4bool fIsCheck = false;
   /// option to print all regions
-  G4bool fIsPrint = false;;
+  G4bool fIsPrint = false;
   /// option to save all regions in a file
-  G4bool fIsSave = false;;
+  G4bool fIsSave = false;
 };
 
 /// Return the singleton instance
@@ -124,18 +140,69 @@ inline TG4VRegionsManager* TG4VRegionsManager::Instance() { return fgInstance; }
 inline void TG4VRegionsManager::SetFileName(const G4String& fileName)
 { fFileName = fileName; }
 
+/// Set the option to apply range cuts for gamma (default is true)
+inline void TG4VRegionsManager::SetApplyForGamma(G4bool applyForGamma)
+{
+  fApplyForGamma = applyForGamma;
+}
+
+/// Set the option to apply range cuts for e- (default is true)
+inline void TG4VRegionsManager::SetApplyForElectron(G4bool applyForElectron)
+{
+  fApplyForElectron = applyForElectron;
+}
+
+/// Set the option to apply range cuts for e+ (default is true)
+inline void TG4VRegionsManager::SetApplyForPositron(G4bool applyForPositron)
+{
+  fApplyForPositron = applyForPositron;
+}
+
+/// Set the option to apply range cuts for proton (default is true)
+inline void TG4VRegionsManager::SetApplyForProton(G4bool applyForProton)
+{
+  fApplyForProton = applyForProton;
+}
+
+/// Set the option to perform consistency check (by default false)
 inline void TG4VRegionsManager::SetCheck(G4bool isCheck)
 { fIsCheck = isCheck; }
 
+/// Set the option to print all regions
 inline void TG4VRegionsManager::SetPrint(G4bool isPrint)
 { fIsPrint = isPrint; }
 
+/// Set the option to save all regions in a file
 inline void TG4VRegionsManager::SetSave(G4bool isSave)
 { fIsSave = isSave; }
 
 /// Return the file name for regions output
 inline G4String TG4VRegionsManager::GetFileName() const
 { return fFileName; }
+
+/// Return the option to apply range cuts for gamma
+inline G4bool TG4VRegionsManager::GetApplyForGamma() const
+{
+  return fApplyForGamma;
+}
+
+/// Return the option to apply range cuts for e+
+inline G4bool TG4VRegionsManager::GetApplyForElectron() const
+{
+  return fApplyForElectron;
+}
+
+/// Return the option to apply range cuts for positron
+inline G4bool TG4VRegionsManager::GetApplyForPositron() const
+{
+  return fApplyForPositron;
+}
+
+/// Return the option to apply range cuts for proton
+inline G4bool TG4VRegionsManager::GetApplyForProton() const
+{
+  return fApplyForProton;
+}
 
 /// Return the option to perform consistency check
 inline G4bool TG4VRegionsManager::IsCheck() const { return fIsCheck; }

--- a/source/run/src/TG4RegionsMessenger.cxx
+++ b/source/run/src/TG4RegionsMessenger.cxx
@@ -103,6 +103,29 @@ void TG4RegionsMessenger::CreateCommands()
   fSetRangePrecisionCmd->SetParameterName("RangePrecision", false);
   fSetRangePrecisionCmd->AvailableForStates(G4State_PreInit, G4State_Init);
 
+  fApplyForGammaCmd = new G4UIcmdWithABool("/mcRegions/applyForGamma", this);
+  fApplyForGammaCmd->SetGuidance("Switch on|off applying range cuts for gamma");
+  fApplyForGammaCmd->SetParameterName("ApplyForGamma", false);
+  fApplyForGammaCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fApplyForElectronCmd =
+    new G4UIcmdWithABool("/mcRegions/applyForElectron", this);
+  fApplyForElectronCmd->SetGuidance("Switch on|off applying range cuts for e-");
+  fApplyForElectronCmd->SetParameterName("ApplyForElectron", false);
+  fApplyForElectronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fApplyForPositronCmd =
+    new G4UIcmdWithABool("/mcRegions/applyForPositron", this);
+  fApplyForPositronCmd->SetGuidance("Switch on|off applying range cuts for e+");
+  fApplyForPositronCmd->SetParameterName("ApplyForPositron", false);
+  fApplyForPositronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
+  fApplyForProtonCmd = new G4UIcmdWithABool("/mcRegions/applyForProton", this);
+  fApplyForProtonCmd->SetGuidance(
+    "Switch on|off applying range cuts for protons");
+  fApplyForProtonCmd->SetParameterName("ApplyForProton", false);
+  fApplyForProtonCmd->AvailableForStates(G4State_PreInit, G4State_Init);
+
   if (fRegionsManager != nullptr) {
     // commands working only with old regions manager
     fDumpRegionCmd = new G4UIcmdWithAString("/mcRegions/dumpRegion", this);
@@ -117,29 +140,6 @@ void TG4RegionsMessenger::CreateCommands()
       "Set the tolerance (relative) for comparing energy cut values");
     fSetEnergyToleranceCmd->SetParameterName("EnergyTolerance", false);
     fSetEnergyToleranceCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-  
-    fApplyForGammaCmd = new G4UIcmdWithABool("/mcRegions/applyForGamma", this);
-    fApplyForGammaCmd->SetGuidance("Switch on|off applying range cuts for gamma");
-    fApplyForGammaCmd->SetParameterName("ApplyForGamma", false);
-    fApplyForGammaCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-  
-    fApplyForElectronCmd =
-      new G4UIcmdWithABool("/mcRegions/applyForElectron", this);
-    fApplyForElectronCmd->SetGuidance("Switch on|off applying range cuts for e-");
-    fApplyForElectronCmd->SetParameterName("ApplyForElectron", false);
-    fApplyForElectronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-  
-    fApplyForPositronCmd =
-      new G4UIcmdWithABool("/mcRegions/applyForPositron", this);
-    fApplyForPositronCmd->SetGuidance("Switch on|off applying range cuts for e+");
-    fApplyForPositronCmd->SetParameterName("ApplyForPositron", false);
-    fApplyForPositronCmd->AvailableForStates(G4State_PreInit, G4State_Init);
-  
-    fApplyForProtonCmd = new G4UIcmdWithABool("/mcRegions/applyForProton", this);
-    fApplyForProtonCmd->SetGuidance(
-      "Switch on|off applying range cuts for protons");
-    fApplyForProtonCmd->SetParameterName("ApplyForProton", false);
-    fApplyForProtonCmd->AvailableForStates(G4State_PreInit, G4State_Init);
   
     fSetLoadCmd = new G4UIcmdWithABool("/mcRegions/load", this);
     fSetLoadCmd->SetGuidance("Switch on|off loading of all regions cuts & ranges from a file");
@@ -165,6 +165,26 @@ void TG4RegionsMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
   /// Apply command to the associated object.
 
   if (fRegionsManager2 != nullptr) {
+    if (command == fApplyForGammaCmd) {
+      fRegionsManager2->SetApplyForGamma(
+        fApplyForGammaCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fApplyForElectronCmd) {
+      fRegionsManager2->SetApplyForGamma(
+        fApplyForElectronCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fApplyForPositronCmd) {
+      fRegionsManager2->SetApplyForPositron(
+        fApplyForPositronCmd->GetNewBoolValue(newValue));
+      return;
+    }
+    if (command == fApplyForProtonCmd) {
+      fRegionsManager2->SetApplyForProton(
+        fApplyForProtonCmd->GetNewBoolValue(newValue));
+      return;
+    }
     if (command == fSetCheckCmd) {
       fRegionsManager2->SetCheck(fSetCheckCmd->GetNewBoolValue(newValue));
       return;
@@ -226,7 +246,7 @@ void TG4RegionsMessenger::SetNewValue(G4UIcommand* command, G4String newValue)
       return;
     }
     if (command == fApplyForElectronCmd) {
-      fRegionsManager->SetApplyForGamma(
+      fRegionsManager->SetApplyForElectron(
         fApplyForElectronCmd->GetNewBoolValue(newValue));
       return;
     }

--- a/source/run/src/TG4VRegionsManager.cxx
+++ b/source/run/src/TG4VRegionsManager.cxx
@@ -73,9 +73,18 @@ G4double TG4VRegionsManager::GetGlobalEnergyCut(TG4G3Cut cutType) const
     TG4G3PhysicsManager::Instance()->GetIsCutVector();
   TG4G3CutVector* cutVector = TG4G3PhysicsManager::Instance()->GetCutVector();
 
-  G4double cutValue = DBL_MAX;
-  if ((*isCutVector)[cutType] && (*cutVector)[cutType] > DBL_MIN) {
+  G4double cutValue = 0.;
+  if ((*isCutVector)[cutType] && (*cutVector)[cutType] > 0.) {
     cutValue = (*cutVector)[cutType];
+  }
+  else {
+    // get g3default and issue a warning
+    TG4Globals::Warning("TG4VRegionsManager", "GetGlobalEnergyCut",
+       "The default cut " + TString(TG4G3CutVector::GetCutName(cutType)) +
+       " is not defined."  + TG4Globals::Endl() + "The default Geant3 value will be used"
+       " for tracking media that do not define this cut." + TG4Globals::Endl());
+
+    cutValue = TG4G3Defaults::Instance()->CutValue(cutType);
   }
 
   return cutValue;
@@ -88,8 +97,8 @@ G4double TG4VRegionsManager::GetEnergyCut(
   /// Return cut in energy defined in limits of given cutType.
   /// Return DBL_MAX if cut value is not defined.
 
-  G4double cut = DBL_MAX;
-  if (limits->GetCutVector() && (*limits->GetCutVector())[cutType] > DBL_MIN) {
+  G4double cut = 0.;
+  if (limits->GetCutVector() && (*limits->GetCutVector())[cutType] > 0.) {
     cut = (*limits->GetCutVector())[cutType];
   }
   else {


### PR DESCRIPTION
- Moved fApplyFor* data members from TG4RegionsManager in TG4VRegionsManager to make them and their related UI commands available also for new way of setting production cuts
- Set EnergyCutVector also for positrons (CUTELE) and protons (HADR)
- Use Geant3 default cut value (from TG4G3Defaults) if it is not set by user via SetCut()