### PR TITLE
test-suite: set ROOT_INCLUDE_PATH if builddir is passed

### DIFF
--- a/examples/test_suite.sh
+++ b/examples/test_suite.sh
@@ -193,11 +193,11 @@ fi
 
 # Set path to shared libraries if --builddir is provided via the option
 if [ "x${BUILDDIR}" != "x" ]; then
-  LIBS_FROM_BUILDDIR=$(find ${BUILDDIR} -iname "*.so" -exec dirname {} \; | tr '\r\n' ':')
+  LIBS_FROM_BUILDDIR=$(find ${BUILDDIR} -iname "*.so" -exec dirname {} \; | uniq | tr '\r\n' ':')
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBS_FROM_BUILDDIR}
   # In that case, also use headers from matching source dirs.
   SOURCEDIR=$(readlink -f ../source/)
-  HEADERS_FROM_SOURCEDIR=$(find ${SOURCEDIR} -iname "*.h" -exec dirname {} \; | tr '\r\n' ':')
+  HEADERS_FROM_SOURCEDIR=$(find ${SOURCEDIR} -iname "*.h" -exec dirname {} \; | uniq | tr '\r\n' ':')
   export ROOT_INCLUDE_PATH=${ROOT_INCLUDE_PATH}:${HEADERS_FROM_SOURCEDIR}
 fi
 

--- a/examples/test_suite.sh
+++ b/examples/test_suite.sh
@@ -195,6 +195,10 @@ fi
 if [ "x${BUILDDIR}" != "x" ]; then
   LIBS_FROM_BUILDDIR=$(find ${BUILDDIR} -iname "*.so" -exec dirname {} \; | tr '\r\n' ':')
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${LIBS_FROM_BUILDDIR}
+  # In that case, also use headers from matching source dirs.
+  SOURCEDIR=$(readlink -f ../source/)
+  HEADERS_FROM_SOURCEDIR=$(find ${SOURCEDIR} -iname "*.h" -exec dirname {} \; | tr '\r\n' ':')
+  export ROOT_INCLUDE_PATH=${ROOT_INCLUDE_PATH}:${HEADERS_FROM_SOURCEDIR}
 fi
 
 # Create tmp dir from scratch


### PR DESCRIPTION
When libraries from the build dir are used, ROOT should also autoload the headers from the corresponding source directory location.
Otherwise, headers of other versions installed earlier may be used, or headers might not be found.

This affects test_suite.sh only, the compiled tests are unaffected.

This fixes the issue observed in https://github.com/gentoo/gentoo/pull/35759 (macro-based tests fail if no earlier version of geant4_vmc is installed), and also prevent potential incompatibility problems by usage of mismatched headers. 

Alternatively to the proposed fix, it would of course also be possible to add a separate `--sourcedir` argument, but since `test_suite.sh` depends on the location in any case (to find the examples), I expect that this is not necessary. 