### PR TITLE
Fix compilation with -DGeant4VMC_USE_G4Root=OFF:

### DIFF
--- a/source/geometry/src/TG4GeometryManager.cxx
+++ b/source/geometry/src/TG4GeometryManager.cxx
@@ -29,11 +29,14 @@
 #include "TG4ModelConfigurationManager.h"
 #include "TG4OpGeometryManager.h"
 #include "TG4RadiatorDescription.h"
-#include "TG4RootDetectorConstruction.h"
 #include "TG4SDManager.h"
 #include "TG4StateManager.h"
 #include "TG4VUserPostDetConstruction.h"
 #include "TG4VUserRegionConstruction.h"
+
+#ifdef USE_G4ROOT
+#include "TG4RootDetectorConstruction.h"
+#endif
 
 #include <G4FieldManager.hh>
 #include <G4LogicalVolumeStore.hh>
@@ -521,7 +524,9 @@ void TG4GeometryManager::FillMediumMapFromRoot()
       geoVolume = gGeoManager->GetVolume(volName.data());
     }
     else {
+#ifdef USE_G4ROOT
       geoVolume = fRootDetectorConstruction->GetVolume(lv);
+#endif
     }
 
     if (!geoVolume) {


### PR DESCRIPTION
- Added compilation flag for unprotected use of G4Root in TG4GeometryManager