### PR TITLE
Added a possibility to exclude particles from a model configuration:

### DIFF
--- a/source/global/include/TG4Globals.h
+++ b/source/global/include/TG4Globals.h
@@ -87,6 +87,7 @@ class TG4Globals
   static G4String Help();
 
   static G4String GetToken(Int_t i, const TString& s);
+  static G4bool Contains(const G4String& name, const G4String& nameList);
 
  private:
   TG4Globals();

--- a/source/global/include/TG4ModelConfiguration.h
+++ b/source/global/include/TG4ModelConfiguration.h
@@ -41,6 +41,7 @@ class TG4ModelConfiguration
 
   // set methods
   void SetParticles(const G4String& particles);
+  void SetExcludedParticles(const G4String& particles);
   void SetRegionsMedia(const G4String& regionsMedia);
   void SetOneRegionMedium(const G4String& regionMedium);
   void SetOneRegion(const G4String& region);
@@ -49,6 +50,7 @@ class TG4ModelConfiguration
   // get methods
   const G4String& GetModelName() const;
   const G4String& GetParticles() const;
+  const G4String& GetExcludedParticles() const;
   const std::vector<G4String>& GetRegionsMedia() const;
   const std::vector<G4String>& GetRegions() const;
   G4VFastSimulationModel* GetFastSimulationModel() const;
@@ -65,6 +67,7 @@ class TG4ModelConfiguration
   // data members
   G4String fModelName;                 ///< the EM model name
   G4String fParticles;                 ///< the list of particle names
+  G4String fExcludedParticles;         ///< the list of excluded particle names
   std::vector<G4String> fRegionsMedia; ///< the vector of regions media
   std::vector<G4String>
     fRegions; ///< the vector of created regions (per materials)
@@ -77,6 +80,12 @@ inline void TG4ModelConfiguration::SetParticles(const G4String& particles)
 {
   /// Set the list of particles
   fParticles = particles;
+}
+
+inline void TG4ModelConfiguration::SetExcludedParticles(const G4String& particles)
+{
+  /// Set the list of particles
+  fExcludedParticles = particles;
 }
 
 inline void TG4ModelConfiguration::SetFastSimulationModel(
@@ -96,6 +105,12 @@ inline const G4String& TG4ModelConfiguration::GetParticles() const
 {
   /// Return the list of particles
   return fParticles;
+}
+
+inline const G4String& TG4ModelConfiguration::GetExcludedParticles() const
+{
+  /// Return the list of particles
+  return fExcludedParticles;
 }
 
 inline const std::vector<G4String>&

--- a/source/global/include/TG4ModelConfigurationManager.h
+++ b/source/global/include/TG4ModelConfigurationManager.h
@@ -45,6 +45,7 @@ class TG4ModelConfigurationManager : public TG4Verbose
   // set methods
   void SetModel(const G4String& modelName);
   void SetModelParticles(const G4String& modelName, const G4String& particles);
+  void SetModelExcludedParticles(const G4String& modelName, const G4String& particles);
   void SetModelRegions(const G4String& modelName, const G4String& regionsMedia);
   void SetOneModelRegion(
     const G4String& modelName, const G4String& regionMedium);

--- a/source/global/include/TG4ModelConfigurationMessenger.h
+++ b/source/global/include/TG4ModelConfigurationMessenger.h
@@ -30,6 +30,7 @@ class G4UIcmdWithAString;
 /// Implements commands:
 /// - /mcPhysics/physicsName/setModel modelName
 /// - /mcPhysics/physicsName/setParticles particleName1 particleName2 ...
+/// - /mcPhysics/physicsName/setExludedParticles particleName1 particleName2 ...
 /// - /mcPhysics/physicsName/setRegions regionName1 regionName2 ...
 /// - /mcPhysics/physicsName/setOneRegion regionName
 /// - /mcPhysics/physicsName/setEmModel modelName  (deprecated)
@@ -76,6 +77,9 @@ class TG4ModelConfigurationMessenger : public G4UImessenger
 
   /// setParticles command
   G4UIcmdWithAString* fSetParticlesCmd;
+
+  /// setExcludedParticles command
+  G4UIcmdWithAString* fSetExcludedParticlesCmd;
 
   /// setRegions command
   G4UIcmdWithAString* fSetRegionsCmd;

--- a/source/global/src/TG4Globals.cxx
+++ b/source/global/src/TG4Globals.cxx
@@ -148,3 +148,22 @@ G4String TG4Globals::GetToken(Int_t i, const TString& s)
   else
     return tokens[i];
 }
+
+//_____________________________________________________________________________
+G4bool TG4Globals::Contains(const G4String& name, const G4String& nameList)
+{
+  /// Append a space to both searched name and the list
+  /// in order to exclude a match for names which are only substrings of
+  /// some name present in the list.
+  /// Eg. when omega_c0 is in the list and omega is checked for a presence
+
+  if (nameList.empty()) return false;
+
+  G4String checkName(name);
+  checkName.append(" ");
+
+  G4String checkNameList(nameList);
+  checkNameList.append(" ");
+
+  return (checkNameList.find(checkName) != std::string::npos);
+}

--- a/source/global/src/TG4ModelConfiguration.cxx
+++ b/source/global/src/TG4ModelConfiguration.cxx
@@ -13,6 +13,7 @@
 /// \author I. Hrivnacova; IPN, Orsay
 
 #include "TG4ModelConfiguration.h"
+#include "TG4Globals.h"
 
 #include <G4AnalysisUtilities.hh>
 
@@ -20,22 +21,6 @@
 
 namespace
 {
-
-G4bool Contains(const G4String& name, const G4String& nameList)
-{
-  // Append a space to both searched name and the list
-  // in order to exclude a match for names which are only substrings of
-  // some name present in the list.
-  // Eg. when Air2 is in the list and Air is checked for a presence
-
-  G4String checkName(name);
-  checkName.append(" ");
-
-  G4String checkNameList(nameList);
-  checkNameList.append(" ");
-
-  return (checkNameList.find(checkName) != std::string::npos);
-}
 
 void PrintNamesVector(const std::vector<G4String> names)
 {
@@ -109,9 +94,12 @@ void TG4ModelConfiguration::Print() const
 //_____________________________________________________________________________
 G4bool TG4ModelConfiguration::HasParticle(const G4String& particleName)
 {
-  /// Return true if given particle is in the particles list
+  /// Return true if given particle is in the particles list and is not
+  /// in the excluded list
 
-  return Contains(particleName, fParticles);
+  return
+    (fParticles == "all" || TG4Globals::Contains(particleName, fParticles)) &&
+    ! (TG4Globals::Contains(particleName, fExcludedParticles));
 }
 
 //_____________________________________________________________________________

--- a/source/global/src/TG4ModelConfigurationManager.cxx
+++ b/source/global/src/TG4ModelConfigurationManager.cxx
@@ -265,6 +265,27 @@ void TG4ModelConfigurationManager::SetModelParticles(
 }
 
 //_____________________________________________________________________________
+void TG4ModelConfigurationManager::SetModelExcludedParticles(
+  const G4String& modelName, const G4String& particles)
+{
+  /// Set particles for the physics model for given medium.
+
+  TG4ModelConfiguration* modelConfiguration =
+    GetModelConfiguration(modelName, "SetModelExcludedParticles");
+
+  if (!modelConfiguration) {
+    TString text = "The model configuration ";
+    text += modelName.data();
+    text += " is not defined.";
+    TG4Globals::Warning("TG4ModelConfigurationManager", "SetModelParticles",
+      text + TG4Globals::Endl() + TString("Setting will be ignored."));
+    return;
+  }
+
+  modelConfiguration->SetExcludedParticles(particles);
+}
+
+//_____________________________________________________________________________
 void TG4ModelConfigurationManager::SetModelRegions(
   const G4String& modelName, const G4String& regionsMedia)
 {

--- a/source/global/src/TG4ModelConfigurationMessenger.cxx
+++ b/source/global/src/TG4ModelConfigurationMessenger.cxx
@@ -52,6 +52,7 @@ TG4ModelConfigurationMessenger::TG4ModelConfigurationMessenger(
     fDirectory(0),
     fSetModelCmd(0),
     fSetParticlesCmd(0),
+    fSetExcludedParticlesCmd(0),
     fSetRegionsCmd(0)
 {
   /// Standard constructor
@@ -92,6 +93,15 @@ TG4ModelConfigurationMessenger::TG4ModelConfigurationMessenger(
   fSetParticlesCmd->SetParameterName("Particles", false);
   fSetParticlesCmd->AvailableForStates(G4State_PreInit);
 
+  // setExcludedParticles command
+  commandName = dirName + "setExcludedParticles";
+  fSetExcludedParticlesCmd = new G4UIcmdWithAString(commandName, this);
+  guidance = "Set to be excluded from the selected extra " + physicsName + "\n" +
+             "if 'all' was selected previously ";
+  fSetExcludedParticlesCmd->SetGuidance(guidance.c_str());
+  fSetExcludedParticlesCmd->SetParameterName("Particles", false);
+  fSetExcludedParticlesCmd->AvailableForStates(G4State_PreInit);
+
   // setRegions command
   commandName = dirName + "setRegions";
   fSetRegionsCmd = new G4UIcmdWithAString(commandName, this);
@@ -123,6 +133,7 @@ TG4ModelConfigurationMessenger::~TG4ModelConfigurationMessenger()
   delete fSetModelCmd;
   delete fSetEmModelCmd;
   delete fSetParticlesCmd;
+  delete fSetExcludedParticlesCmd;
   delete fSetRegionsCmd;
   delete fSetOneRegionCmd;
 }
@@ -143,6 +154,9 @@ void TG4ModelConfigurationMessenger::SetNewValue(
   }
   else if (command == fSetParticlesCmd) {
     fModelConfigurationManager->SetModelParticles(fSelectedModel, newValue);
+  }
+  else if (command == fSetExcludedParticlesCmd) {
+    fModelConfigurationManager->SetModelExcludedParticles(fSelectedModel, newValue);
   }
   else if (command == fSetRegionsCmd) {
     fModelConfigurationManager->SetModelRegions(fSelectedModel, newValue);

--- a/source/physics_list/src/TG4EmModelPhysics.cxx
+++ b/source/physics_list/src/TG4EmModelPhysics.cxx
@@ -268,7 +268,6 @@ void TG4EmModelPhysics::AddModels(
 
     // Get model configuration
     TG4EmModel emModel = GetEmModel((*it)->GetModelName());
-    G4String particles = (*it)->GetParticles();
     const std::vector<G4String>& regions = (*it)->GetRegions();
 
     if (!regions.size()) {
@@ -287,11 +286,8 @@ void TG4EmModelPhysics::AddModels(
       G4ParticleDefinition* particle = aParticleIterator->value();
       G4String particleName = particle->GetParticleName();
 
-      // skip particles which are not in selection
-      if (particles != "all" &&
-          particles.find(particle->GetParticleName()) == std::string::npos) {
-        continue;
-      }
+      // skip particles which are not in the model configuration selection
+      if (! (*it)->HasParticle(particleName) ) continue;
 
       // skip also monopole (experimental)
       if (particle->GetParticleName() == "monopole") {

--- a/source/physics_list/src/TG4ExtDecayerPhysics.cxx
+++ b/source/physics_list/src/TG4ExtDecayerPhysics.cxx
@@ -23,27 +23,6 @@
 #include <G4ParticleDefinition.hh>
 #include <G4ProcessManager.hh>
 
-namespace
-{
-
-G4bool Contains(const G4String& name, const G4String& nameList)
-{
-  // Append a space to both searched name and the list
-  // in order to exclude a match for names which are only substrings of
-  // some name present in the list.
-  // Eg. when omega_c0 is in the list and omega is checked for a presence
-
-  G4String checkName(name);
-  checkName.append(" ");
-
-  G4String checkNameList(nameList);
-  checkNameList.append(" ");
-
-  return (checkNameList.find(checkName) != std::string::npos);
-}
-
-} // namespace
-
 //_____________________________________________________________________________
 TG4ExtDecayerPhysics::TG4ExtDecayerPhysics(const G4String& name)
   : TG4VPhysicsConstructor(name),
@@ -117,7 +96,7 @@ void TG4ExtDecayerPhysics::ConstructProcess()
     // skip particles which do not have process manager
     if (!pmanager) continue;
 
-    if (Contains(particle->GetParticleName(), fSelection)) {
+    if (TG4Globals::Contains(particle->GetParticleName(), fSelection)) {
 
       if (VerboseLevel() > 1) {
         G4cout << "Switching off Geant4 decay table for: "

--- a/source/physics_list/src/TG4FastSimulationPhysics.cxx
+++ b/source/physics_list/src/TG4FastSimulationPhysics.cxx
@@ -182,7 +182,6 @@ void TG4FastSimulationPhysics::AddFastSimulationProcess(
 
     // Get model name
     G4String modelName = (*it)->GetModelName();
-    G4String particles = (*it)->GetParticles();
 
     // Get or create fast simulation process
     G4FastSimulationManagerProcess* fastSimulationProcess =
@@ -195,10 +194,8 @@ void TG4FastSimulationPhysics::AddFastSimulationProcess(
       G4ParticleDefinition* particle = aParticleIterator->value();
       G4String particleName = particle->GetParticleName();
 
-      // skip particles which are not in selection
-      if (particles != "all" && (!(*it)->HasParticle(particleName))) {
-        continue;
-      }
+      // skip particles which are not in the model configuration selection
+      if (! (*it)->HasParticle(particleName) ) continue;
 
       // skip particles which do not have process manager
       if (!particle->GetProcessManager()) continue;

--- a/source/physics_list/src/TG4StackPopperPhysics.cxx
+++ b/source/physics_list/src/TG4StackPopperPhysics.cxx
@@ -14,29 +14,9 @@
 
 #include "TG4StackPopperPhysics.h"
 #include "TG4StackPopper.h"
+#include "TG4Globals.h"
 
 #include <G4ProcessManager.hh>
-
-namespace
-{
-
-G4bool Contains(const G4String& name, const G4String& nameList)
-{
-  // Append a space to both searched name and the list
-  // in order to exclude a match for names which are only substrings of
-  // some name present in the list.
-  // Eg. when omega_c0 is in the list and omega is checked for a presence
-
-  G4String checkName(name);
-  checkName.append(" ");
-
-  G4String checkNameList(nameList);
-  checkNameList.append(" ");
-
-  return (checkNameList.find(checkName) != std::string::npos);
-}
-
-} // namespace
 
 //_____________________________________________________________________________
 TG4StackPopperPhysics::TG4StackPopperPhysics(const G4String& name)
@@ -97,7 +77,7 @@ void TG4StackPopperPhysics::ConstructProcess()
 
     // add this as an option
     if (fSelection.size() == 0 ||
-        Contains(particle->GetParticleName(), fSelection)) {
+        TG4Globals::Contains(particle->GetParticleName(), fSelection)) {
 
       if (VerboseLevel() > 1) {
         G4cout << "Adding StackPopper process to "


### PR DESCRIPTION
- Enhanced TG4ModelConfiguration with fExcludedParticles, and take the excluded particles list into account in HasParticle()
- Added a UI command: /mcPhysics/physicsName/setExludedParticles particleName1 particleName2 ... Example: /mcPhysics/emModel/setEmModel  PAI /mcPhysics/emModel/setRegions  TRD_Gas-mix /mcPhysics/emModel/setParticles  all /mcPhysics/emModel/setExcludedParticles  GenericIon alpha
- Moved Contains(const G4String&, const G4String&) function defined in unnamed namespace in several .cxx file into TG4Globals to avoid duplication