### PR TITLE
Fixed setting productions cuts per energy in MT mode;

### DIFF
--- a/source/global/include/TG4G3Defaults.h
+++ b/source/global/include/TG4G3Defaults.h
@@ -54,7 +54,7 @@ class TG4G3Defaults
   TG4G3Defaults& operator=(const TG4G3Defaults& right);
 
   // static data members
-  static G4ThreadLocal TG4G3Defaults* fgInstance; ///< this instance
+  static TG4G3Defaults* fgInstance; ///< this instance
 
   // data members
   TG4G3CutVector fCutVector;         ///< vector of default cut values

--- a/source/global/src/TG4G3Defaults.cxx
+++ b/source/global/src/TG4G3Defaults.cxx
@@ -21,7 +21,7 @@
 
 // static data members
 
-G4ThreadLocal TG4G3Defaults* TG4G3Defaults::fgInstance = 0;
+TG4G3Defaults* TG4G3Defaults::fgInstance = 0;
 
 //_____________________________________________________________________________
 TG4G3Defaults::TG4G3Defaults() : fCutVector(), fControlVector()

--- a/source/physics/src/TG4G3PhysicsManager.cxx
+++ b/source/physics/src/TG4G3PhysicsManager.cxx
@@ -15,7 +15,6 @@
 #include "TG4G3PhysicsManager.h"
 #include "TG4G3ControlVector.h"
 #include "TG4G3CutVector.h"
-#include "TG4G3Defaults.h"
 #include "TG4G3Units.h"
 
 #include <G4ParticleDefinition.hh>

--- a/source/run/src/TG4RegionsManager2.cxx
+++ b/source/run/src/TG4RegionsManager2.cxx
@@ -148,8 +148,14 @@ void TG4RegionsManager2::UpdateProductionCutsTable()
   // G4cout << "g4ProductionCutsTable size: " << g4ProductionCutsTable->GetTableSize() << G4endl;
 
   // update table (create materials cut couples)
-  g4ProductionCutsTable->CreateCoupleTables(); 
+  g4ProductionCutsTable->CreateCoupleTables();
   // G4cout << "g4ProductionCutsTable size after update: " << g4ProductionCutsTable->GetTableSize() << G4endl;
+  // reset materials to force cuts recalculation
+  for (std::size_t i = 0; i < g4ProductionCutsTable->GetTableSize(); ++i) {
+    auto couple = const_cast<G4MaterialCutsCouple*>(g4ProductionCutsTable->GetMaterialCutsCouple(i));
+    auto material = couple->GetMaterial();
+    couple->SetMaterial(material);
+  }
 
   for (std::size_t i = 0; i < g4ProductionCutsTable->GetTableSize(); ++i) {
     auto couple = g4ProductionCutsTable->GetMaterialCutsCouple(i);


### PR DESCRIPTION
- Added a temprary workaround to force cuts recalculation in G4ProductionCutsTable by resetting materials in cuts couples. (To be removed when a fix in G4ProductionCutsTable is available.)
- Do not define TG4G3Defaults thread-local, as they are associated with non thread-local TG4G3PhysicsManger singleton