### PR TITLE
Add an option to activate Geant4 command-line scoring

### DIFF
--- a/source/run/include/TG4RunConfiguration.h
+++ b/source/run/include/TG4RunConfiguration.h
@@ -102,6 +102,7 @@ class TG4RunConfiguration
   void SetMTApplication(Bool_t mtApplication);
   void SetParameter(const TString& name, Double_t value);
   void SetSpecialCutsOld();
+  void SetUseOfG4Scoring();
 
   // get methods
   TString GetUserGeometry() const;
@@ -110,6 +111,7 @@ class TG4RunConfiguration
   Bool_t IsSpecialControls() const;
   Bool_t IsSpecialCuts() const;
   Bool_t IsSpecialCutsOld() const;
+  Bool_t IsUseOfG4Scoring() const;
   Bool_t IsMTApplication() const;
 
  protected:
@@ -122,6 +124,7 @@ class TG4RunConfiguration
   Bool_t fSpecialControls;          ///< option for special controls
   Bool_t fSpecialCuts;              ///< option for special cuts
   Bool_t fSpecialCutsOld;           ///< option for special cuts old
+  Bool_t fUseOfG4Scoring;           ///< option to activate G4 commmand-line scoring
   G4UImessenger* fAGDDMessenger;    //!< XML messenger
   G4UImessenger* fGDMLMessenger;    //!< XML messenger
 
@@ -141,10 +144,21 @@ class TG4RunConfiguration
 
 // inline functions
 
+/// Activate G4 commmand-line scoring
+inline void TG4RunConfiguration::SetUseOfG4Scoring()
+{
+  fUseOfG4Scoring = true;
+}
+
 /// Return physics list selection
 inline TString TG4RunConfiguration::GetPhysicsListSelection() const
 { 
   return fPhysicsListSelection;
+}
+
+inline Bool_t TG4RunConfiguration::IsUseOfG4Scoring() const
+{
+  return fUseOfG4Scoring;
 }
 
 #endif // TG4V_RUN_CONFIGURATION_H

--- a/source/run/include/TG4RunManager.h
+++ b/source/run/include/TG4RunManager.h
@@ -28,7 +28,6 @@ class TG4VRegionsManager;
 
 class G4RunManager;
 class G4UIExecutive;
-class G4VScoreNtupleWriter;
 
 class TApplication;
 class TMCManager;
@@ -109,7 +108,6 @@ class TG4RunManager : public TG4Verbose
   TG4VRegionsManager* fRegionsManager;    ///< regions manager
   G4UIExecutive* fGeantUISession;         ///< G4 UI
   TApplication* fRootUISession;           ///< Root UI
-  G4VScoreNtupleWriter* fG4ScoreNtupleWriter; ///< Geant4 scoring ntuple writer
   G4bool fRootUIOwner;                    ///< ownership of Root UI
   G4int fARGC;                            ///< argc
   char** fARGV;                           ///< argv

--- a/source/run/include/TG4RunManager.h
+++ b/source/run/include/TG4RunManager.h
@@ -28,6 +28,7 @@ class TG4VRegionsManager;
 
 class G4RunManager;
 class G4UIExecutive;
+class G4VScoreNtupleWriter;
 
 class TApplication;
 class TMCManager;
@@ -108,6 +109,7 @@ class TG4RunManager : public TG4Verbose
   TG4VRegionsManager* fRegionsManager;    ///< regions manager
   G4UIExecutive* fGeantUISession;         ///< G4 UI
   TApplication* fRootUISession;           ///< Root UI
+  G4VScoreNtupleWriter* fG4ScoreNtupleWriter; ///< Geant4 scoring ntuple writer
   G4bool fRootUIOwner;                    ///< ownership of Root UI
   G4int fARGC;                            ///< argc
   char** fARGV;                           ///< argv

--- a/source/run/src/TG4RunConfiguration.cxx
+++ b/source/run/src/TG4RunConfiguration.cxx
@@ -49,6 +49,7 @@ TG4RunConfiguration::TG4RunConfiguration(const TString& userGeometry,
     fSpecialControls(false),
     fSpecialCuts(false),
     fSpecialCutsOld(false),
+    fUseOfG4Scoring(false),
     fAGDDMessenger(0),
     fGDMLMessenger(0),
     fParameters()

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -44,6 +44,7 @@
 #else
 #include <G4RunManager.hh>
 #endif
+#include <G4ScoringManager.hh>
 
 #include <G4UIExecutive.hh>
 #include <G4UImanager.hh>
@@ -142,6 +143,11 @@ TG4RunManager::TG4RunManager(
     fRegionsManager = fgMasterInstance->fRegionsManager;
     fRootUISession = fgMasterInstance->fRootUISession;
     fGeantUISession = fgMasterInstance->fGeantUISession;
+  }
+
+  if (runConfiguration->IsUseOfG4Scoring()) {
+    // activate G4 command-line scoring
+    G4ScoringManager::GetScoringManager();
   }
 
   if (VerboseLevel() > 1) {


### PR DESCRIPTION
The activation should be done via calling `TG4RunConfiguration::SetUseOfG4Scoring()` in user `Config.C`