### PR TITLE
interface to user score weighting

### DIFF
--- a/source/digits+hits/include/TG4SDManager.h
+++ b/source/digits+hits/include/TG4SDManager.h
@@ -16,13 +16,16 @@
 /// \author I. Hrivnacova; IPN, Orsay
 
 #include <globals.hh>
-
+#include <functional>
 #include <Rtypes.h>
 
 class TG4SDServices;
 class TG4SDConstruction;
 
 class TVirtualMCSensitiveDetector;
+class G4Step;
+
+using ScoreWeightCalculatorG4 = std::function<G4double(const G4Step*)>;
 
 /// \ingroup digits_hits
 /// \brief Geant4 implementation of the TVirtualMC interface methods
@@ -41,6 +44,7 @@ class TG4SDManager
 
   // methods
   void Initialize();
+  void LateInitialize(ScoreWeightCalculatorG4 calc);
 
   // TVirtualMC methods
   Int_t VolId(const Text_t* volName) const;

--- a/source/digits+hits/src/TG4SDManager.cxx
+++ b/source/digits+hits/src/TG4SDManager.cxx
@@ -67,6 +67,41 @@ void TG4SDManager::Initialize()
   // G4cout << "TG4SDManager::Initialize done" << G4endl;
 }
 
+#include "G4MultiFunctionalDetector.hh"
+#include "G4PSCellFlux.hh"
+#include "G4ScoringManager.hh"
+#include "G4VPrimitiveScorer.hh"
+#include "G4VScoringMesh.hh"
+
+//_____________________________________________________________________________
+void TG4SDManager::LateInitialize(ScoreWeightCalculatorG4 swc)
+{
+  // Apply score weight if use of Geant4 scoring is activated
+
+   auto g4ScoringManager = G4ScoringManager::GetScoringManagerIfExist();
+   if (g4ScoringManager == nullptr ) return;
+
+   // Loop over existing scoring meshes
+  auto nofMesh = g4ScoringManager->GetNumberOfMesh();
+  if (nofMesh < 1) return;
+
+  G4cout << "Printing scorers for " << nofMesh << " meshes" << G4endl;
+  for (std::size_t i = 0; i < nofMesh; ++i) {
+    auto mesh = g4ScoringManager->GetMesh((G4int)i);
+    const auto mfd = mesh->GetMFD();
+    G4int nps = mfd->GetNumberOfPrimitives();
+    for(G4int i = 0; i < nps; ++i) {
+      auto scorer = mfd->GetPrimitive(i);
+      // auto cellFlux = dynamic_cast<G4PSCellFlux*>(scorer);
+      G4cout << "Looping over " << scorer->GetName() << G4endl;
+      // if (cellFlux != nullptr) {
+        G4cout << " is weightScoring activated "  << scorer->IsScoreWeighted() << G4endl;
+        scorer->SetScoreWeightCalculator(swc);
+      // }
+    }
+  }
+}
+
 //_____________________________________________________________________________
 Int_t TG4SDManager::VolId(const Text_t* volName) const
 {

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -45,15 +45,11 @@
 #include <G4RunManager.hh>
 #endif
 
-#include <G4ScoringManager.hh>
-#include <G4VScoringMesh.hh>
-
 #include <G4UIExecutive.hh>
 #include <G4UImanager.hh>
 #include <G4UIsession.hh>
 #include <G4Version.hh>
 #include <Randomize.hh>
-
 
 #ifdef USE_G4ROOT
 #include <TG4RootNavMgr.h>
@@ -68,6 +64,8 @@
 #include <TRint.h>
 #include <TVirtualMC.h>
 #include <TVirtualMCApplication.h>
+#include <G4ScoringManager.hh>
+#include <G4VScoringMesh.hh>
 
 namespace
 {
@@ -132,14 +130,12 @@ TG4RunManager::TG4RunManager(
 
   if (isMaster) {
     fgMasterInstance = this;
-
-    // create and configure G4 run manager
-    ConfigureRunManager();
-
     if (runConfiguration->IsUseOfG4Scoring()) {
       // activate G4 command-line scoring
       G4ScoringManager::GetScoringManager();
     }
+    // create and configure G4 run manager
+    ConfigureRunManager();
   }
   else {
     // Get G4 worker run manager
@@ -477,7 +473,8 @@ void TG4RunManager::LateInitialize()
   TG4PhysicsManager::Instance()->SetProcessActivation();
   TG4PhysicsManager::Instance()->RetrieveOpBoundaryProcess();
 
-  // late initialize step manager
+  // late initialize SD and step manager
+  TG4SDManager::Instance()->LateInitialize(fRunConfiguration->GetScoreWeightCalculatorG4());
   TG4StepManager::Instance()->LateInitialize();
 
   // late initialize action classes


### PR DESCRIPTION

The implementation avoids having direct GEANT4 dependence in user code  via G4Step and also having a concrete implementation of the weight function (and data) in GEANT4_VMC. So the implementation is currently the following:

Add to TG4RunConfiguration.h a setter for a  scoreweight function that takes (pdg, ekin) as arguments to avoid G4Step dependence in O2.  A method GetScoreWeightCalculatorG4() converts (wraps) this into the corresponding function with G4Step as argument.

In TG4SDManager.h, the method LateInitialize(ScoreWeightCalculatorG4 calc) takes the scoreweight function as an argument. It is called by TG4RunManager using the G4 signature conversion mentioned above.
