### PR TITLE
Added interface to user score weighting:

### DIFF
--- a/source/digits+hits/include/TG4SDManager.h
+++ b/source/digits+hits/include/TG4SDManager.h
@@ -15,8 +15,9 @@
 ///
 /// \author I. Hrivnacova; IPN, Orsay
 
-#include <globals.hh>
+#include "TG4ScoreWeightCalculator.h"
 
+#include <globals.hh>
 #include <Rtypes.h>
 
 class TG4SDServices;
@@ -41,6 +42,7 @@ class TG4SDManager
 
   // methods
   void Initialize();
+  void LateInitialize(TG4ScoreWeightCalculator swc);
 
   // TVirtualMC methods
   Int_t VolId(const Text_t* volName) const;
@@ -77,6 +79,9 @@ class TG4SDManager
 
   /// services related with sensitive detectors
   TG4SDServices* fSDServices;
+
+  /// score weight calculator
+  TG4ScoreWeightCalculator fScoreWeightCalculator;
 
   /// buffer for volume name
   mutable G4String fNameBuffer;

--- a/source/digits+hits/include/TG4ScoreWeightCalculator.h
+++ b/source/digits+hits/include/TG4ScoreWeightCalculator.h
@@ -1,0 +1,24 @@
+#ifndef TG4_SCORE_WEIGHT_CALCULATOR_H
+#define TG4_SCORE_WEIGHT_CALCULATOR_H
+
+//------------------------------------------------
+// The Geant4 Virtual Monte Carlo package
+// Copyright (C) 2014 - 2018 Ivana Hrivnacova
+// All rights reserved.
+//
+// For the licensing terms see geant4_vmc/LICENSE.
+// Contact: root-vmc@cern.ch
+//-------------------------------------------------
+
+/// \file TG4ScoreWeightCalculator.h
+/// \brief Definition of the score weight calculator type
+///
+/// \author I. Hrivnacova; IPN, Orsay
+
+#include <Rtypes.h>
+
+#include <functional>
+
+using TG4ScoreWeightCalculator = std::function<Double_t(Int_t pdg, Double_t ekin)>;
+
+#endif // TG4_SCORE_WEIGHT_CALCULATOR_H

--- a/source/run/include/TG4RunConfiguration.h
+++ b/source/run/include/TG4RunConfiguration.h
@@ -15,6 +15,8 @@
 ///
 /// \author I. Hrivnacova; IPN Orsay
 
+#include "TG4ScoreWeightCalculator.h"
+
 #include <Rtypes.h>
 #include <TString.h>
 
@@ -103,6 +105,7 @@ class TG4RunConfiguration
   void SetParameter(const TString& name, Double_t value);
   void SetSpecialCutsOld();
   void SetUseOfG4Scoring();
+  void SetScoreWeightCalculator(TG4ScoreWeightCalculator swc);
 
   // get methods
   TString GetUserGeometry() const;
@@ -112,7 +115,9 @@ class TG4RunConfiguration
   Bool_t IsSpecialCuts() const;
   Bool_t IsSpecialCutsOld() const;
   Bool_t IsUseOfG4Scoring() const;
+  Bool_t IsUseOfScoreWeighting() const;
   Bool_t IsMTApplication() const;
+  TG4ScoreWeightCalculator GetScoreWeightCalculator() const;
 
  protected:
   // data members
@@ -125,9 +130,10 @@ class TG4RunConfiguration
   Bool_t fSpecialCuts;              ///< option for special cuts
   Bool_t fSpecialCutsOld;           ///< option for special cuts old
   Bool_t fUseOfG4Scoring;           ///< option to activate G4 commmand-line scoring
+  Bool_t fUseOfScoreWeighting;      ///< option to activate score weighting
   G4UImessenger* fAGDDMessenger;    //!< XML messenger
   G4UImessenger* fGDMLMessenger;    //!< XML messenger
-
+  TG4ScoreWeightCalculator fScoreWeightCalculator; //!< User Scoring Weight Calculator
   /// The map of special parameters which need to be set before creating TGeant4
   /// Actually used for monopole properties:
   /// monopoleMass, monopoleElCharge, monopoleMagCharge
@@ -150,6 +156,13 @@ inline void TG4RunConfiguration::SetUseOfG4Scoring()
   fUseOfG4Scoring = true;
 }
 
+/// Set User Scoring Weight Calculator
+inline void TG4RunConfiguration::SetScoreWeightCalculator(TG4ScoreWeightCalculator swc)
+{
+  fUseOfScoreWeighting = true;
+  fScoreWeightCalculator = swc;
+}
+
 /// Return physics list selection
 inline TString TG4RunConfiguration::GetPhysicsListSelection() const
 { 
@@ -159,6 +172,16 @@ inline TString TG4RunConfiguration::GetPhysicsListSelection() const
 inline Bool_t TG4RunConfiguration::IsUseOfG4Scoring() const
 {
   return fUseOfG4Scoring;
+}
+
+inline Bool_t TG4RunConfiguration::IsUseOfScoreWeighting() const
+{
+  return fUseOfScoreWeighting;
+}
+
+inline TG4ScoreWeightCalculator TG4RunConfiguration::GetScoreWeightCalculator() const
+{
+  return fScoreWeightCalculator;
 }
 
 #endif // TG4V_RUN_CONFIGURATION_H

--- a/source/run/src/TG4RunConfiguration.cxx
+++ b/source/run/src/TG4RunConfiguration.cxx
@@ -50,6 +50,7 @@ TG4RunConfiguration::TG4RunConfiguration(const TString& userGeometry,
     fSpecialCuts(false),
     fSpecialCutsOld(false),
     fUseOfG4Scoring(false),
+    fUseOfScoreWeighting(false),
     fAGDDMessenger(0),
     fGDMLMessenger(0),
     fParameters()

--- a/source/run/src/TG4RunManager.cxx
+++ b/source/run/src/TG4RunManager.cxx
@@ -54,7 +54,6 @@
 #include <G4Version.hh>
 #include <Randomize.hh>
 
-
 #ifdef USE_G4ROOT
 #include <TG4RootNavMgr.h>
 #endif
@@ -132,14 +131,12 @@ TG4RunManager::TG4RunManager(
 
   if (isMaster) {
     fgMasterInstance = this;
-
-    // create and configure G4 run manager
-    ConfigureRunManager();
-
     if (runConfiguration->IsUseOfG4Scoring()) {
       // activate G4 command-line scoring
       G4ScoringManager::GetScoringManager();
     }
+    // create and configure G4 run manager
+    ConfigureRunManager();
   }
   else {
     // Get G4 worker run manager
@@ -476,6 +473,12 @@ void TG4RunManager::LateInitialize()
   // activate/inactivate physics processes
   TG4PhysicsManager::Instance()->SetProcessActivation();
   TG4PhysicsManager::Instance()->RetrieveOpBoundaryProcess();
+
+  // late initialize SD manager
+  // (needed only if user sets score weight calculator)
+  if (fRunConfiguration->IsUseOfScoreWeighting()) {
+    TG4SDManager::Instance()->LateInitialize(fRunConfiguration->GetScoreWeightCalculator());
+  }
 
   // late initialize step manager
   TG4StepManager::Instance()->LateInitialize();


### PR DESCRIPTION
Added TG4ScoreWeightCalculator type for user score weight function that takes (pdg, ekin) as arguments and its setter to the TG4RunConfiguration class:
`   void SetScoreWeightCalculator(TG4ScoreWeightCalculator swc);
`
The user function is then, in TG4SDManager::LateInitialize(), wrapped to G4ScoreWeightCalculator function that takes (const G4Step*) as argument and applied to all Geant4 scorers with activated score weighting.