### PR TITLE
Fixed ROOT IO in examples in multi-threaded mode:

### DIFF
--- a/examples/A01/read.C
+++ b/examples/A01/read.C
@@ -10,21 +10,15 @@
 /// \file A01/read.C
 /// \brief Macro for reading the A01 simulated data from Root file
 
-#include "../macro/basiclibs.C"
-
 void read()
 {
 /// Macro for reading the E03 simulated data from Root file
-
-  // Load basic libraries
-  basiclibs();
-
-  // Load this example library
-  gSystem->Load("libexampleA01");
+/// Note that since Root 6 the libraries have to be loaded first
+/// via load_g4.C.
 
   // MC application
   A01MCApplication* appl
-    =  new A01MCApplication("Example A01", "The Example A01 MC application", kRead);
+    =  new A01MCApplication("Example A01", "The Example A01 MC application",);
 
   for (Int_t i=0; i<5; i++) {
     cout << "   Event no " << i+1 << ":" << endl;

--- a/examples/A01/src/A01MCApplication.cxx
+++ b/examples/A01/src/A01MCApplication.cxx
@@ -283,7 +283,9 @@ void A01MCApplication::InitOnWorker()
   // cout << "A01MCApplication::InitForWorker " << this << endl;
 
   // Create Root manager
-  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+  Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
   // fRootManager->SetDebug(true);
 
   // Set data to MC
@@ -308,6 +310,10 @@ void A01MCApplication::ReadEvent(Int_t i)
 {
   /// Read \em i -th event and print hits.
   /// \param i The number of event to be read
+
+  if ( ! fRootManager ) {
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kRead);
+  }
 
   fDriftChamberSD1->Register();
   fDriftChamberSD2->Register();

--- a/examples/E02/src/Ex02MCApplication.cxx
+++ b/examples/E02/src/Ex02MCApplication.cxx
@@ -212,7 +212,9 @@ void Ex02MCApplication::InitOnWorker()
   // cout << "Ex02MCApplication::InitForWorker " << this << endl;
 
   // Create Root manager
-  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+  Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
   // fRootManager->SetDebug(true);
 
   // Set data to MC

--- a/examples/E03/E03a/src/Ex03MCApplication.cxx
+++ b/examples/E03/E03a/src/Ex03MCApplication.cxx
@@ -247,7 +247,9 @@ void Ex03MCApplication::InitOnWorker()
   // cout << "Ex03MCApplication::InitForWorker " << this << endl;
 
   // Create Root manager
-  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+  Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
   // fRootManager->SetDebug(true);
 
   // Set data to MC
@@ -272,6 +274,10 @@ void Ex03MCApplication::ReadEvent(Int_t i)
 {
   /// Read \em i -th event and prints hits.
   /// \param i The number of event to be read
+
+  if ( ! fRootManager ) {
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kRead);
+  }
 
   fCalorimeterSD->Register();
   RegisterStack();

--- a/examples/E03/E03b/src/Ex03bMCApplication.cxx
+++ b/examples/E03/E03b/src/Ex03bMCApplication.cxx
@@ -247,7 +247,9 @@ void Ex03bMCApplication::InitOnWorker()
   // cout << "Ex03bMCApplication::InitForWorker " << this << endl;
 
   // Create Root manager
-  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+  Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
   // fRootManager->SetDebug(true);
 
   // Set data to MC
@@ -272,6 +274,10 @@ void Ex03bMCApplication::ReadEvent(Int_t i)
 {
   /// Read \em i -th event and prints hits.
   /// \param i The number of event to be read
+
+  if ( ! fRootManager ) {
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kRead);
+  }
 
   fCalorimeterSD->Register();
   RegisterStack();

--- a/examples/E03/E03c/src/Ex03cMCApplication.cxx
+++ b/examples/E03/E03c/src/Ex03cMCApplication.cxx
@@ -393,7 +393,9 @@ void Ex03cMCApplication::InitOnWorker()
   // cout << "Ex03cMCApplication::InitForWorker " << this << endl;
 
   // Create Root manager
-  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+  Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
   // fRootManager->SetDebug(true);
 
   // Set data to MC
@@ -418,6 +420,10 @@ void Ex03cMCApplication::ReadEvent(Int_t i)
 {
   /// Read \em i -th event and prints hits.
   /// \param i The number of event to be read
+
+  if ( ! fRootManager ) {
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kRead);
+  }
 
   fCalorimeterSD->Register();
   RegisterStack();

--- a/examples/E03/read.C
+++ b/examples/E03/read.C
@@ -11,21 +11,15 @@
 /// \file E03/read.C
 /// \brief Macro for reading the E03 simulated data from Root file
 
-#include "../macro/basiclibs.C"
-
 void read()
 {
 /// Macro for reading the E03 simulated data from Root file
-
-  // Load basic libraries
-  basiclibs();
-
-  // Load this example library
-  gSystem->Load("libexample03");
+/// Note that since Root 6 the libraries have to be loaded first
+/// via load_g4a[b,c].C.
 
   // MC application
   Ex03MCApplication* appl
-    =  new Ex03MCApplication("Example03", "The example03 MC application", kRead);
+    =  new Ex03MCApplication("Example03", "The example03 MC application");
 
   for (Int_t i=0; i<5; i++) {
     cout << "   Event no " << i+1 << ":" << endl;

--- a/examples/ExGarfield/read.C
+++ b/examples/ExGarfield/read.C
@@ -10,24 +10,15 @@
 /// \file ExGarfield/read.C
 /// \brief Macro for reading the Garfield simulated data from Root file
 
-#include "../macro/basiclibs.C"
-
 void read()
 {
 /// Macro for reading the Garfield simulated data from Root file
-
-  // Load basic libraries
-  basiclibs();
-
-  // Load Garfield library
-  gSystem->Load("libGarfield");
-
-  // Load this example library
-  gSystem->Load("libvmc_ExGarfield");
+/// Note that since Root 6 the libraries have to be loaded first
+/// via load_g4.C.
 
   // MC application
   VMC::Garfield::MCApplication* appl
-    =  new VMC::ExGarfield::MCApplication("ExampleGarfield", "The example ExGarfield MC application", kRead);
+    =  new VMC::ExGarfield::MCApplication("ExampleGarfield", "The example ExGarfield MC application");
 
   for (Int_t i=0; i<5; i++) {
     cout << "   Event no " << i+1 << ":" << endl;

--- a/examples/ExGarfield/src/MCApplication.cxx
+++ b/examples/ExGarfield/src/MCApplication.cxx
@@ -224,7 +224,9 @@ ClassImp(VMC::ExGarfield::MCApplication)
     // cout << "MCApplication::InitForWorker " << this << endl;
 
     // Create Root manager
-    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+    Int_t threadRank = 1;
+      // The real thread rank will be set in MCRootManager
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
     // fRootManager->SetDebug(true);
 
     // Set data to MC
@@ -248,6 +250,10 @@ ClassImp(VMC::ExGarfield::MCApplication)
   {
     /// Read \em i -th event and prints hits.
     /// \param i The number of event to be read
+
+    if ( ! fRootManager ) {
+      fRootManager = new TMCRootManager(GetName(), TMCRootManager::kRead);
+    }
 
     fSensitiveDetector->Register();
     RegisterStack();

--- a/examples/Gflash/read.C
+++ b/examples/Gflash/read.C
@@ -10,21 +10,15 @@
 /// \file Gflash/read.C
 /// \brief Macro for reading the Gflash simulated data from Root file
 
-#include "../macro/basiclibs.C"
-
 void read()
 {
 /// Macro for reading the Gflash simulated data from Root file
-
-  // Load basic libraries
-  basiclibs();
-
-  // Load this example library
-  gSystem->Load("libexampleGflash");
+/// Note that since Root 6 the libraries have to be loaded first
+/// via load_g4.C.
 
   // MC application
   VMC::Gflash::MCApplication* appl
-    =  new VMC::Gflash::MCApplication("ExampleGflash", "The exampleGflash MC application", kRead);
+    =  new VMC::Gflash::MCApplication("ExampleGflash", "The exampleGflash MC application");
 
   for (Int_t i=0; i<5; i++) {
     cout << "   Event no " << i+1 << ":" << endl;

--- a/examples/Gflash/src/MCApplication.cxx
+++ b/examples/Gflash/src/MCApplication.cxx
@@ -306,7 +306,9 @@ ClassImp(VMC::Gflash::MCApplication)
     // cout << "MCApplication::InitForWorker " << this << endl;
 
     // Create Root manager
-    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+    Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
     // fRootManager->SetDebug(true);
 
     // Set data to MC
@@ -330,6 +332,10 @@ ClassImp(VMC::Gflash::MCApplication)
   {
     /// Read \em i -th event and prints hits.
     /// \param i The number of event to be read
+
+    if ( ! fRootManager ) {
+      fRootManager = new TMCRootManager(GetName(), TMCRootManager::kRead);
+    }
 
     fSensitiveDetector->Register();
     RegisterStack();

--- a/examples/Monopole/src/MCApplication.cxx
+++ b/examples/Monopole/src/MCApplication.cxx
@@ -324,9 +324,10 @@ TVirtualMCApplication* MCApplication::CloneForWorker() const
 void MCApplication::InitOnWorker()
 {
   // Create Root manager
-  fRootManager
-    = new TMCRootManager(GetName(), TMCRootManager::kWrite);
-  //fRootManager->SetDebug(true);
+  Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+  fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
+  // fRootManager->SetDebug(true);
 
   gMC->SetStack(fStack);
   gMC->SetMagField(fMagField);

--- a/examples/TR/src/MCApplication.cxx
+++ b/examples/TR/src/MCApplication.cxx
@@ -276,7 +276,9 @@ ClassImp(VMC::TR::MCApplication)
     // cout << "MCApplication::InitForWorker " << this << endl;
 
     // Create Root manager
-    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite);
+    Int_t threadRank = 1;
+        // The real thread rank will be set in MCRootManager
+    fRootManager = new TMCRootManager(GetName(), TMCRootManager::kWrite, threadRank);
     // fRootManager->SetDebug(true);
 
     // Set data to MC


### PR DESCRIPTION
- Fixed MCApplication:
  - Specify threadRank when creating Root IO Manager on workers
  - Create Root IO Manager in ReadEvent(), if it does not exist
- Fixed read.C macros:
  - Updated for removal of the MCApplication constructor third parameter (Read/Write opyion)
  - Removed loading libraries - since Root 6 the libraries have to be loaded separately